### PR TITLE
[#11] add responsive CSS for top menubar

### DIFF
--- a/static/css/simple-responsive.css
+++ b/static/css/simple-responsive.css
@@ -1,0 +1,33 @@
+/* Simple Responsive Navigation - Two Row Layout */
+@media (max-width: 768px) {
+    .navigation {
+        padding: 8px 16px !important;
+    }
+    .div-block-3 {
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 2px 8px;
+        grid-template: none;
+    }
+    .link {
+        margin: 0 6px;
+        padding: 4px 8px;
+        white-space: nowrap;
+    }
+    .link:hover {
+        background-color: rgba(255, 255, 255, 0.1);
+    }
+}
+
+@media (max-width: 490px) {
+    .navigation {
+        padding: 6px 12px !important;
+    }
+    .div-block-3 {
+        gap: 1px 4px;
+    }
+    .link {
+        margin: 0 3px;
+        padding: 3px 6px;
+    }
+}

--- a/templates/layout.haml
+++ b/templates/layout.haml
@@ -9,6 +9,7 @@
     %link{:href => "/css/normalize.css", :rel => "stylesheet", :type => "text/css"}/
     %link{:href => "/css/webflow.css", :rel => "stylesheet", :type => "text/css"}/
     %link{:href => "/css/ksru-web.webflow.css", :rel => "stylesheet", :type => "text/css"}/
+    %link{:href => "/css/simple-responsive.css", :rel => "stylesheet", :type => "text/css"}/
     %script{:src => "https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js", :type => "text/javascript"}
     :javascript
       WebFont.load({


### PR DESCRIPTION
fixes #11

Laptop:
<img width="1728" alt="Screenshot 2025-06-05 at 11 08 57 PM" src="https://github.com/user-attachments/assets/0d283231-1808-4bff-91cd-e10440469832" />

Mobile (428x926):
<img width="461" alt="Screenshot 2025-06-05 at 11 23 52 PM" src="https://github.com/user-attachments/assets/1357e967-9bae-4f4e-9a97-4f1a0bfbcea4" />
