### PR TITLE
Add LinkedIn social + layout/a11y improvements

### DIFF
--- a/pages/socials/index.haml
+++ b/pages/socials/index.haml
@@ -3,10 +3,24 @@
 .section-2
   %p.paragraph{:style => "align: center"}
     Follow us on social media:
-    %a{:href => "https://bsky.app/profile/kickstarterunited.org", :rel => "me", :target => "_blank"} 🦋 Bluesky
-    &nbsp;
-    %a{:href => "https://www.instagram.com/kickstarter_united", :rel => "me", :target => "_blank"} 📷 Instagram
-    &nbsp;
-    %a{:href => "https://union.place/@kickstarterunited", :rel => "me", :target => "_blank"} 🐘 Mastodon
-    &nbsp;
-    %a{:href => "https://twitter.com/ksr_united", :target => "_blank"} 💩 Twitter
+    -# NOTE: When updating, also update templates/layout.haml
+    -#
+    -# Below, we want these to be inline with the paragraph text, so we use
+    -# spans instead of list items. The `role` attributes are for accessibility.
+    %span.social-links{role: "list"}
+      %span{role: "listitem"}
+        🦋
+        %a{:href => "https://bsky.app/profile/kickstarterunited.org", :rel => "me", :target => "_blank"} Bluesky
+      %span{role: "listitem"}
+        📷
+        %a{:href => "https://www.instagram.com/kickstarter_united", :rel => "me", :target => "_blank"} Instagram
+      %span{role: "listitem"}
+        💼
+        %a{:href => "https://www.linkedin.com/in/kickstarter-united-4924ba37b/", :rel => "me", :target => "_blank"} LinkedIn
+      %span{role: "listitem"}
+        🐘
+        %a{:href => "https://union.place/@kickstarterunited", :rel => "me", :target => "_blank"} Mastodon
+      %span{role: "listitem"}
+        💩
+        %a{:href => "https://twitter.com/ksr_united", :target => "_blank"} Twitter
+

--- a/static/css/ksru-web.webflow.css
+++ b/static/css/ksru-web.webflow.css
@@ -1,3 +1,25 @@
+
+.footer {
+  color: #ffffff;
+}
+
+.footer a:any-link {
+  color: currentColor;
+}
+
+.social-links {
+  margin: 0;
+  padding: 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.social-links > * {
+  display: flex;
+  gap: 4px;
+}
+
 .w-commerce-commercecheckoutformcontainer {
   width: 100%;
   min-height: 100vh;

--- a/templates/layout.haml
+++ b/templates/layout.haml
@@ -49,7 +49,7 @@
       %footer.section-7.footer
         .text-block
           -# NOTE: When updating, also update pages/socials/index.haml
-          %ul.social-links
+          %ul.social-links{"aria-label": "Follow us on social media"}
             %li
               🦋
               %a{:href => "https://bsky.app/profile/kickstarterunited.org", :rel => "me", :target => "_blank"} Bluesky

--- a/templates/layout.haml
+++ b/templates/layout.haml
@@ -46,16 +46,25 @@
           %a.link{:href => "/faq"} FAQ
       .div-block-2
         != yield
-      .section-7
+      %footer.section-7.footer
         .text-block
-          %span
-            %a.footer{:href => "https://bsky.app/profile/kickstarterunited.org", :rel => "me", :target => "_blank"} 🦋 Bluesky
-            &nbsp;
-            %a.footer{:href => "https://www.instagram.com/kickstarter_united", :rel => "me", :target => "_blank"} 📷 Instagram
-            &nbsp;
-            %a.footer{:href => "https://union.place/@kickstarterunited", :rel => "me", :target => "_blank"} 🐘 Mastodon
-            &nbsp;
-            %a.footer{:href => "https://twitter.com/ksr_united", :target => "_blank"} 💩 Twitter
+          -# NOTE: When updating, also update pages/socials/index.haml
+          %ul.social-links
+            %li
+              🦋
+              %a{:href => "https://bsky.app/profile/kickstarterunited.org", :rel => "me", :target => "_blank"} Bluesky
+            %li
+              📷
+              %a{:href => "https://www.instagram.com/kickstarter_united", :rel => "me", :target => "_blank"} Instagram
+            %li
+              💼
+              %a{:href => "https://www.linkedin.com/in/kickstarter-united-4924ba37b/", :rel => "me", :target => "_blank"} LinkedIn
+            %li
+              🐘
+              %a{:href => "https://union.place/@kickstarterunited", :rel => "me", :target => "_blank"} Mastodon
+            %li
+              💩
+              %a{:href => "https://twitter.com/ksr_united", :target => "_blank"} Twitter
           %br
           © Copyright 2023 Kickstarter United
     %script{:crossorigin => "anonymous", :integrity => "sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=", :src => "https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.4.1.min.220afd743d.js", :type => "text/javascript"}


### PR DESCRIPTION
Adds our LinkedIn profile to the /socials page as well as the site footer.

Also adds accessibility and readability improvements.

**before**
<img width="1153" height="571" alt="image" src="https://github.com/user-attachments/assets/ff494b27-8414-40e3-a69a-a5b873b41084" />

**after**
<img width="1131" height="569" alt="image" src="https://github.com/user-attachments/assets/3fb989bb-380a-4119-b8a6-48bc389ae859" />

