### PR TITLE
2025 Refresh: Update typography

### DIFF
--- a/pages/about/index.haml
+++ b/pages/about/index.haml
@@ -1,6 +1,8 @@
 .section
   %img.image{:alt => "Kickstarter United Logo", :src => "../images/logo.svg", :width => "256"}/
 #about.section-2
+  %h1 About Us
+
   %p.paragraph
     On February 18th, 2020, Kickstarter employees voted to form a union,
     becoming the first major tech company in the United States to do so.

--- a/pages/contracts/2022/index.haml
+++ b/pages/contracts/2022/index.haml
@@ -1,7 +1,7 @@
 .section
   %img.image{:alt => "A screenshot of a Zoom meeting where our Bargaining Unit members were celebrating their first contract", :src => "/images/first_contract/BU.png"}/
 .section-2
-  %h2.heading-3
+  %h1.heading-3
     Our first contract
   %p.paragraph
     It’s official! On June 17th, 2022, 97.6% of our union voted YES to ratify our first collective bargaining agreement.
@@ -50,7 +50,7 @@
     If you have any questions about our contract, please free to use our contact form. We'll try to answer at our earliest convenience.
 
 .section-4
-  %h5
+  %h2
     Statements from our members
 
   %img.image{:alt => '"The tech industry is an unpredictable and rapidly changing one, and having certain guarantees about pay, fair treatment, and even potentially severance makes me feel a lot more stable. Knowing what to expect with your pay over the next few years, what you\'re guaranteed in case of layoffs, and even knowing what your bonus scheme will be or how much time off you\'ll receive give me that many fewer things to worry about. On top of all that, the addition of fairness clauses like not paying some people less because of where they live and having regular pay equity reviews lessen my worry that some people will be mistreated." Chris Cerami, Senior Software Engineer @ Kickstarter since July 2021', :src => "/images/first_contract/quote1.png", :style => "width: 75%;"}

--- a/pages/faq/index.haml
+++ b/pages/faq/index.haml
@@ -1,21 +1,21 @@
 #faq.section
-  %h2.heading-3 Frequently Asked Questions
+  %h1.heading-3 Frequently Asked Questions
   .collection-list-wrapper-3.w-dyn-list
-    .collection-list-2.w-dyn-items
-      .w-dyn-item
-        %h4 What is Kickstarter United?
+    %div{role: "list"}
+      %div{role: "listitem"}
+        %b What is Kickstarter United?
         %p.paragraph.w-richtext<
           Kickstarter United is the union that represents the employees of Kickstarter, PBC. We are part of
           %a{href: 'https://www.opeiulocal153.org/'} OPEIU Local 153
           and are also associated with
           %a{href: 'https://www.techworkersunion-1010.org/'} OPEIU's Tech Workers Union Local 1010
-      .w-dyn-item{style: 'margin-top: 48px;'}
-        %h4 How does the 4-day work week (4DWW) work at Kickstarter?
+      %div{role: "listitem", style: 'margin-top: 48px;'}
+        %b How does the 4-day work week (4DWW) work at Kickstarter?
         %p.paragraph.w-richtext Kickstarter embarked on a 4DWW 32 hour pilot in April of 2022. The premise of that pilot can be summarized by 100-80-100. That means 100% of the work is completed in 80% of the time for 100% of the pay. The important piece is that 100% of the work is getting done in less time. Same work done = same pay.
-      .w-dyn-item{style: 'margin-top: 48px;'}
-        %h4 Has the 4DWW been a success?
+      %div{role: "listitem", style: 'margin-top: 48px;'}
+        %b Has the 4DWW been a success?
         %p.paragraph.w-richtext Kickstarter management sure thinks so - they’ve talked about it extensively over the years - and we workers agree! Our output has remained the same but our work life balance has improved immensely and it’s been a great recruiting tool for the company. Some folks even took pay cuts to come work a 4-day work week at Kickstarter.
-      .w-dyn-item{style: 'margin-top: 48px;'}
-        %h4 So what’s the sticking point on the 4DWW in contract negotiations?
+      %div{role: "listitem", style: 'margin-top: 48px;'}
+        %b So what’s the sticking point on the 4DWW in contract negotiations?
         %p.paragraph.w-richtext Management wants to retain the right to both temporarily and permanently alter our work schedule back to a 5-day, 40-hour work week. We’ve offered several proposals that allow for the occasional and temporary need to shift schedules, but so far these have all been rejected. Management claims that flexibility must extend to the ability to permanently increase our working hours, despite operating successfully on a 4DWW for 3 years, because they can’t foresee what challenges the business will face.
         %p.paragraph.w-richtext They would want us to retain our increased productivity that we gained from the 4DWW, but while working longer hours again, essentially trying to have us do 125% of the work we were doing prior to the 4DWW being implemented, but with no extra pay or time off.

--- a/pages/index.haml
+++ b/pages/index.haml
@@ -1,7 +1,7 @@
 .section
   %img.image{:alt => "Kickstarter United Logo", :src => "images/logo.svg", :width => "256"}/
 .section-2
-  %h3 Our Next Contract
+  %h1 Our Next Contract
   %p.paragraph
     In July of 2025 we began bargaining with the management at Kickstarter for our second union contract (our
     %a{:href => "/contracts/2022", :style => "display: inline;"} first
@@ -20,7 +20,7 @@
 
 
 .section-2
-  %h3 What You Can Do
+  %h2 What You Can Do
   %div.rally__toc
     %ul.rally__links{role: "list"}
       %li
@@ -32,10 +32,10 @@
 
   %section#solidarity-fund
     - go_fund_me_url = "https://www.gofundme.com/f/support-kickstarter-united-workers"
-    %header 
-      %h4 Donate to Our Solidarity Fund
+    %header
+      %h3 Donate to Our Solidarity Fund
       %p
-        On Labor Day we launched our Solidarity fund on GoFundMe. If management forces a strike, 
+        On Labor Day we launched our Solidarity fund on GoFundMe. If management forces a strike,
         this GoFundMe will help our most vulnerable workers weather the hardship of pay-stoppage.
     %article.fund
       .fund__main
@@ -44,11 +44,11 @@
 
       .fund__aside
         %p
-          If we reach an agreement without striking, we will refund any donation on request and roll 
+          If we reach an agreement without striking, we will refund any donation on request and roll
           the remaining funds into a sympathetic solidarity and/or hardship fund to help our fellow workers
 
   %section#solidarity-petition{ style: "margin-top: 2rem;" }
-    %h4 Sign Our Solidarity Petition
+    %h3 Sign Our Solidarity Petition
 
     %p.paragraph
       We are asking
@@ -63,21 +63,21 @@
       #can-petition-area-ksru-solidarity-petition
         -# {:style => "width: 70%; margin: 0 auto;"}
         -# this div is the target for our HTML insertion
-  
+
   %section#solidarity-rally{ style: "margin-top: 2rem;" }
     - rally_recording_url = "https://us06web.zoom.us/rec/share/6OKlx_dx69PNAN5KD4RXHGUEMnJ4guwswqFwYpm00wfOAAs7JTyy847bMTYFgPfH.tu_yKEq1X0jhpnSB"
     %header
-      %h4 Watch Our Solidarity Rally
+      %h3 Watch Our Solidarity Rally
 
       %p On September 5th, we held a public virtual rally to support our fight for a fair contract.
-      %p 
+      %p
         We featured unionized tech workers who’ve gone on strike, elected representatives who support a 32-hour week, and
         Kickstarter United members discussing our our demands and our union.
 
     %article.rally
       .rally__main
         %div.rally__card
-          %h5 Rally Details
+          %h4 Rally Details
 
           %div
             %p.rally__logistics
@@ -98,7 +98,7 @@
               %a.link{:href => "https://docs.google.com/forms/d/e/1FAIpQLSd3JgEtyy72nD6zAwdZsIMeJ5PMg3pIOtkwR7l1uooCJI9bTA/viewform", :target => "_blank"} Contact us for the webinar passcode.
 
       .rally__aside
-        %h5 Featured speakers and supporters
+        %h4 Featured speakers and supporters
         %ul
           %li
             %b The New York Times Tech Guild:

--- a/pages/may-day-severance-agreement/index.haml
+++ b/pages/may-day-severance-agreement/index.haml
@@ -1,5 +1,5 @@
 #about.section-2
-  %h2.heading-3 Statement from Kickstarter United
+  %h1.heading-3 Statement from Kickstarter United
   %p
     On Monday, April 20th, Kickstarter management
     %a{:href => "https://www.theverge.com/2020/4/20/21228412/kickstarter-layoffs-planned-coronavirus-project-declines-crowdfunding-union", :style => "display: inline"} announced

--- a/pages/oral-history/index.haml
+++ b/pages/oral-history/index.haml
@@ -1,12 +1,12 @@
 .section
   %img.image{:alt => "Kickstarter United Oral History logo", :src => "/images/ksruoralhistory-cover.jpg", :width => "50%"}/
 .section-2
-  %h2.heading-3
+  %h1.heading-3
     The Kickstarter United Oral History
   %p.paragraph<
     In 2020, one of our former organizers,
     %a{:href=>"https://twitter.com/clarissaredwine", :title=>"Clarissa's Twitter account", :target=>"_blank"}>Clarissa Redwine
-    , teamed up with 
+    , teamed up with
     %a{:href=> "https://www.law.nyu.edu/centers/engelberg", :title => "NYU's Engelberg Center", :target=>"_blank"}NYU's Engelberg Center
     to compile an oral history of our union from genesis all the way to the vote win.
     You can also search for "Engelberg Center Live!" in your podcast app of choice to find
@@ -15,11 +15,11 @@
   %iframe{:scrolling => "no", :seamless => "true", :frameborder => "no", :height => "200px", :width => "100%", :src => "https://player.simplecast.com/1b922782-a7f5-43eb-8291-a27650725db1?dark=false", :title => "Introducing an Oral History of the Kickstarter Union"}
 
   %iframe{:scrolling => "no", :seamless => "true", :frameborder => "no", :height => "200px", :width => "100%", :src => "https://player.simplecast.com/27cc8fad-ca0e-4f96-a0b4-fd809be079c5?dark=false", :title => "One on Ones"}
-  
+
   %iframe{:scrolling => "no", :seamless => "true", :frameborder => "no", :height => "200px", :width => "100%", :src => "https://player.simplecast.com/201c8bb5-5379-4cea-bfdf-5aa0c2bcc008?dark=false", :title => "Documentation"}
 
   %iframe{:scrolling => "no", :seamless => "true", :frameborder => "no", :height => "200px", :width => "100%", :src => "https://player.simplecast.com/5b163cb0-099c-40ef-aa78-ad1c283a595d?dark=false", :title => "Unions in Tech"}
-  
+
   %iframe{:scrolling => "no", :seamless => "true", :frameborder => "no", :height => "200px", :width => "100%", :src => "https://player.simplecast.com/de10aa75-cc7c-4d83-9910-dffc94b55ecc?dark=false", :title => "Chapter 1: Fertile Ground"}
 
   %iframe{:scrolling => "no", :seamless => "true", :frameborder => "no", :height => "200px", :width => "100%", :src => "https://player.simplecast.com/1b2f2abd-68f5-4b0e-b48b-6be2bd41cafd?dark=false", :title => "Chapter 2: Catalyst"}
@@ -27,7 +27,7 @@
   %iframe{:scrolling => "no", :seamless => "true", :frameborder => "no", :height => "200px", :width => "100%", :src => "https://player.simplecast.com/e9fff6a9-7aba-4683-aa07-f1d0007b2bcc?dark=false", :title => "Chapter 3: Solidarity"}
 
   %iframe{:scrolling => "no", :seamless => "true", :frameborder => "no", :height => "200px", :width => "100%", :src => "https://player.simplecast.com/9683a773-e3eb-417c-a980-14db219dd5ed?dark=false", :title => "Chapter 4: The Leak"}
-  
+
   %iframe{:scrolling => "no", :seamless => "true", :frameborder => "no", :height => "200px", :width => "100%", :src => "https://player.simplecast.com/ea781ce9-4e00-45b5-a876-9de115550c6c?dark=false", :title => "Chapter 5: Captive Audience | Part 1"}
 
   %iframe{:scrolling => "no", :seamless => "true", :frameborder => "no", :height => "200px", :width => "100%", :src => "https://player.simplecast.com/4ddb3e7d-4f32-462b-9310-466d4393bbd1?dark=false", :title => "Chapter 5: Captive Audience | Part 2"}

--- a/pages/press/index.haml
+++ b/pages/press/index.haml
@@ -1,54 +1,54 @@
 #press.section
-  %h2.heading-3 Selected Press and Media Coverage:
+  %h1.heading-3 Selected Press and Media Coverage:
   .collection-list-wrapper-3.w-dyn-list
     .collection-list-2.w-dyn-items
       .w-dyn-item
-        %h5 The Oral History
+        %b The Oral History
         .w-richtext
           %a{:href => "/oral-history"}
             “An oral history of our union, hosted by the Engelberg Center and compiled by one of our former organizers.”
       .w-dyn-item
-        %h5 01) New York Times
+        %b 01) New York Times
         .w-richtext
           %a{:target => "_blank", :href => "https://www.nytimes.com/2020/02/18/technology/kickstarter-union.html"}
             “Kickstarter Employees Vote to Unionize in a Big Step for Tech”
       .w-dyn-item
-        %h5 02) Washington Post
+        %b 02) Washington Post
         .w-richtext
           %a{:target => "_blank", :href => "https://www.washingtonpost.com/business/2020/02/18/kickstarter-forms-union/"}
             “Kickstarter staff votes to unionize, a sign of rising labor tensions in tech”
       .w-dyn-item
-        %h5 03) The Guardian
+        %b 03) The Guardian
         .w-richtext
           %a{:target => "_blank", :href => "https://www.theguardian.com/us-news/2020/feb/18/kickstarter-union-crowdfunding-tech"}
             “Kickstarter workers vote to unionize amid growing industry unrest”
       .w-dyn-item
-        %h5 04) Vice
+        %b 04) Vice
         .w-richtext
           %a{:target => "_blank", :href => "https://www.vice.com/en_us/article/3a8pp5/kickstarter-employees-win-historic-union-election"}
             “Kickstarter Employees Win Historic Union Election”
       .w-dyn-item
-        %h5 05) Forbes
+        %b 05) Forbes
         .w-richtext
           %a{:target => "_blank", :href => "https://www.forbes.com/sites/mattperez/2020/02/18/kickstarter-staff-votes-to-unionize-paving-the-way-for-other-tech-workers/#73e8a73404f0"}
             “Kickstarter Staff Votes To Unionize, Paving The Way For Other Tech Workers”
       .w-dyn-item
-        %h5 06) Business Insider
+        %b 06) Business Insider
         .w-richtext
           %a{:target => "_blank", :href => "https://www.businessinsider.com/kickstarter-union-employees-tech-workers-2020-2"}
             “Kickstarter has unionized, becoming the first tech company to do so as workers organize across the industry”
       .w-dyn-item
-        %h5 07) The Verge
+        %b 07) The Verge
         .w-richtext
           %a{:target => "_blank", :href => "https://www.theverge.com/2020/2/18/21142308/kickstarter-employee-vote-union-unionize"}
             “Kickstarter employees vote to unionize”
       .w-dyn-item
-        %h5 08) Kickstarter Union Oral History
+        %b 08) Kickstarter Union Oral History
         .w-richtext
           %a{:target => "_blank", :href => "https://engelberg-center-live.simplecast.com/"}
             “A podcast featuring an oral history directly from our organizers and members”
       .w-dyn-item
-        %h5 09) Crain's New York
+        %b 09) Crain's New York
         .w-richtext
           %a{:target => "_blank", :href => "https://www.crainsnewyork.com/labor-unions/kickstarter-workers-win-profit-sharing-and-guaranteed-raises-first-union-contract"}
             “Kickstarter workers win profit sharing and guaranteed raises in first union contract”

--- a/pages/socials/index.haml
+++ b/pages/socials/index.haml
@@ -1,6 +1,7 @@
 .section
   %img.image{:alt => "Kickstarter United Logo", :src => "../images/logo.svg", :width => "256"}/
 .section-2
+  %h1 Our Socials
   %p.paragraph{:style => "align: center"}
     Follow us on social media:
     -# NOTE: When updating, also update templates/layout.haml

--- a/static/css/ksru-web.webflow.css
+++ b/static/css/ksru-web.webflow.css
@@ -44,6 +44,16 @@
   h1, h2, h3, h4, h5, h6 {
     font-family: var(--ksru-font-family-heading);
   }
+
+  /* Musical hexatonic scale: 𝑓ᵢ = 𝑓₀𝑟ⁱ⁄ⁿ, n=6, r=2, 𝑓₀=1em */
+  h1 { font-size: 2em; }
+  h2 { font-size: 1.7818em; }
+  h3 { font-size: 1.5874em; }
+  h4 { font-size: 1.4142em; }
+  h5 { font-size: 1.2599em; }
+  h6 { font-size: 1.1225em; }
+  p { font-size: 1em; }
+  small { font-size: .8909em; }
 }
 
 @layer components {

--- a/static/css/ksru-web.webflow.css
+++ b/static/css/ksru-web.webflow.css
@@ -47,6 +47,7 @@
 
   h1, h2, h3, h4, h5, h6 {
     font-family: var(--ksru-font-family-heading);
+    line-height: 1.2;
   }
 
   /* Musical hexatonic scale: 𝑓ᵢ = 𝑓₀𝑟ⁱ⁄ⁿ, n=6, r=2, 𝑓₀=1em */
@@ -131,14 +132,13 @@
     gap: 4px;
   }
 
-
-
   .section, .section-2, .div-block {
     font-family: unset;
   }
 
   .body {
     font-size: unset;
+    line-height: 1.6;
     font-family: var(--ksru-font-family-body);
   }
 }

--- a/static/css/ksru-web.webflow.css
+++ b/static/css/ksru-web.webflow.css
@@ -1,4 +1,26 @@
 @layer base {
+  html {
+    /* Fallback fonts */
+    --ksru-font-stack-system: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+    /* Font families */
+    --ksru-font-family-jost: 'Jost', var(--ksru-font-stack-system, sans-serif);
+    --ksru-font-family-libre-franklin: 'Libre Franklin', var(--ksru-font-stack-system, sans-serif);
+
+    /* Content types */
+    --ksru-font-family-heading: var(--ksru-font-family-jost, monospace);
+
+    --ksru-font-family-body: var(--ksru-font-family-libre-franklin, sans-serif);
+
+    --ksru-line-length: 80ch;
+
+    font-size: 100%;
+  }
+
+  body {
+    font-family: var(--ksru-font-family-body);
+  }
+
   a {
     display: inline;
     color: currentColor;
@@ -17,6 +39,10 @@
   html {
     scroll-behavior: smooth;
     scroll-padding: 6rem 0 0;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--ksru-font-family-heading);
   }
 }
 
@@ -89,6 +115,17 @@
     margin: 0;
     display: flex;
     gap: 4px;
+  }
+
+
+
+  .section, .section-2, .div-block {
+    font-family: unset;
+  }
+
+  .body {
+    font-size: unset;
+    font-family: var(--ksru-font-family-body);
   }
 }
 

--- a/static/css/ksru-web.webflow.css
+++ b/static/css/ksru-web.webflow.css
@@ -17,6 +17,10 @@
     font-size: 100%;
   }
 
+  * + :is(p, ul, ol, dl, blockquote, pre, table, hr) {
+    margin: 1rem 0 0;
+  }
+
   body {
     font-family: var(--ksru-font-family-body);
   }

--- a/templates/layout.haml
+++ b/templates/layout.haml
@@ -6,32 +6,17 @@
     %meta{:content => "Kickstarter United", :property => "og:title"}/
     %meta{:content => "/images/logo.svg", :property => "og:image"}/
     %meta{:content => "width=device-width, initial-scale=1", :name => "viewport"}/
+
+    %link{rel: "preconnect", href: "https://fonts.googleapis.com"}
+    %link{rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: true}
+    %link{href: "https://fonts.googleapis.com/css2?family=Jost:ital,wght@0,100..900;1,100..900&family=Libre+Franklin:ital,wght@0,100..900;1,100..900&display=swap", rel: "stylesheet"}
+
     %style @layer normalize, legacy, base, components, utilities;
     %link{:href => "/css/normalize.css", :rel => "stylesheet", :type => "text/css"}/
     %link{:href => "/css/ksru-web.webflow.css", :rel => "stylesheet", :type => "text/css"}/
     %link{:href => "/css/rally.css", :rel => "stylesheet", :type => "text/css"}/
     %link{:href => "/css/fund.css", :rel => "stylesheet", :type => "text/css"}/
     %link{:href => "/css/simple-responsive.css", :rel => "stylesheet", :type => "text/css"}/
-    %script{:src => "https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js", :type => "text/javascript"}
-    :javascript
-      WebFont.load({
-        google: {
-          families: [
-            "Montserrat:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic,900,900italic",
-            "Inconsolata:400,700",
-          ],
-        },
-      });
-    / [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif]
-    :javascript
-      !(function (o, c) {
-        var n = c.documentElement,
-          t = " w-mod-";
-        (n.className += t + "js"),
-          ("ontouchstart" in o ||
-            (o.DocumentTouch && c instanceof DocumentTouch)) &&
-            (n.className += t + "touch");
-      })(window, document);
     %link{:href => "/images/favicon.ico", :rel => "shortcut icon", :type => "image/x-icon"}/
     %link{:href => "/images/webclip.png", :rel => "apple-touch-icon"}/
   %body.body


### PR DESCRIPTION
Refreshes the typography to help with readability and quality.

* Swaps Inconsolata for Jost (headings) and Libre Franklin (prose/content)
* Updates to a musical hexatonic font scale
* Adds auto spacing for prose/text elements
* Fixes mismatches of HTML heading levels

**before**

<img width="1337" height="1417" alt="Screenshot 2025-09-06 at 10 45 18 AM" src="https://github.com/user-attachments/assets/2de09886-575a-4dab-add9-ffa6efcaf54e" />


**after**
<img width="1337" height="1417" alt="Screenshot 2025-09-06 at 11 23 20 AM" src="https://github.com/user-attachments/assets/1aa62fb0-6fb7-4806-8a37-8ea2639b5f32" />

