### PR TITLE
Adjust days on strike

### DIFF
--- a/pages/index.haml
+++ b/pages/index.haml
@@ -1,16 +1,19 @@
-.days-on-strike
-  %div.container
-    %img.image{:alt => "Kickstarter United Logo", :src => "images/logo.svg", :width => "256"}
-  %div.container
+%article.days-on-strike.gap-12.flex.flex-col.md:flex-row.items-stretch{
+  class: "[corner-shape:squircle]"
+}
+  %div.flex-1.shrink.basis-auto.self-center
+    %img.justify-self-center{:alt => "Kickstarter United Logo", :src => "images/logo.svg", :width => "256"}
+  %div.days-on-strike__bill
     %span.pump.text-center{role: "presentation", "aria-hidden": "true"}
       ✊🏿 ✊🏾 ✊🏽 ✊🏼 ✊🏻
     %h2.text-center
       Days on strike
-      %span#day-count.day-count{"aria-live" => "polite"} 0
+    %p#day-count.day-count
+      0
     %p.text-center
       Since October 2, 2025
-    %div.flex.flex-wrap.justify-between.gap-x-2
-      %a.btn.btn-success.text-center{href: '#what-you-can-do'}> How to Support
+
+    %a.btn.btn-success.justify-self-stretch{href: '#what-you-can-do'}> How to Support
 
 %article.surface.breaking
   %h2.flex.flex-wrap.justify-between.gap-x-2

--- a/src/css/components/days-on-strike.css
+++ b/src/css/components/days-on-strike.css
@@ -1,12 +1,9 @@
 @layer components {
   .days-on-strike {
-    margin-right: auto;
-    margin-left: auto;
-    width: auto;
     border: 5px solid var(--ksru-color-accent-light);
     border-radius: 28px;
-    padding: clamp(20px, 3vw, 36px);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+    padding: 32px;
+    @apply shadow-lg;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -16,11 +13,21 @@
     margin-top: 32px;
   }
 
+  .days-on-strike__bill {
+    @apply flex-2 shrink-0 basis-auto
+      grid place-items-center
+      border border-green-900/10 p-6 rounded-2xl
+      bg-green-50 text-green-950
+      inset-shadow-sm inset-shadow-gray-300;
+  }
+
   .days-on-strike .day-count {
     font-size: 3em;
     display: block;
     color: var(--ksru-color-accent-light);
     visibility: hidden;
+
+    @apply shadow-sm shadow-gray-200 border border-gray-300 rounded mx-auto min-w-[2ch] px-6 text-center bg-white aspect-square content-center;
   }
 
   .days-on-strike .pump {

--- a/src/css/ksru-web.webflow.css
+++ b/src/css/ksru-web.webflow.css
@@ -157,8 +157,11 @@
 
 
 @layer components {
-  button, .btn {
-    display: inline-block;
+  button,
+  .btn {
+    display: block;
+    font: inherit;
+    font-weight: 500;
     box-sizing: border-box;
     min-width: 44px;
     min-height: 44px;
@@ -169,9 +172,8 @@
     font-size: 16px;
     margin-top: 10px;
     cursor: pointer;
-    width: 100%;
     text-decoration: none;
-    color: var(--ksru-color-bg);
+    text-align: center;
   }
 
   * + :is(button, .btn) {
@@ -189,18 +191,22 @@
 
   .btn-success {
     background: var(--ksru-color-accent-light);
+    color: var(--ksru-text-accent);
   }
 
   .btn-success:hover {
-    background: #039054;
+    background: color-mix(in oklch, var(--ksru-color-accent-light), white 20%);
+    color: var(--ksru-text-accent);
   }
 
   .btn-info {
-    background: #17a2b8;
+    background: var(--color-teal-600);
+    color: var(--ksru-text-accent);
   }
 
   .btn-info:hover {
-    background: #138496;
+    background: var(--color-teal-500);
+    color: var(--ksru-text-accent);
   }
 }
 


### PR DESCRIPTION
Aligns styling of Days on Strike with the site. Also adds some visual cues for separation of content

<img width="835" height="456" alt="image" src="https://github.com/user-attachments/assets/535bcecb-8f1a-448f-bfc6-5b2c7a790bde" />
