### PR TITLE
attempt to fix broken images on creator assets page

### DIFF
--- a/pages/union-assets/index.haml
+++ b/pages/union-assets/index.haml
@@ -2,13 +2,13 @@
 %p Please use these assets in your campaign story and thumbnail image to express support for Kickstarter United!
 
 .border-4.p-4.mt-4.bg-gray-200
-  %img{src: "images/union_assets/banner-1.png"}
+  %img{src: "/images/union_assets/banner-1.png"}
   .mt-6.mb-1.flex
     %a.no-underline.text-black.border-4.w-auto.bg-white.px-6.py-3.mt-1{href: "images/union_assets/banner-1.png", download: true, type: "image/png"}
       Download
 
 .border-4.p-4.mt-4.bg-gray-200
-  %img{src: "images/union_assets/banner-2-large.png"}
+  %img{src: "/images/union_assets/banner-2-large.png"}
   .mt-6.mb-1.flex
     %a.no-underline.text-black.border-4.w-auto.bg-white.px-6.py-3{href: "images/union_assets/banner-2-large.png", download: true, type: "image/png"}
       Download (large)
@@ -16,13 +16,13 @@
       Download (small)
 
 .border-4.p-4.mt-4.bg-gray-200
-  %img{src: "images/union_assets/banner-3.png"}
+  %img{src: "/images/union_assets/banner-3.png"}
   .mt-6.mb-1.flex
     %a.no-underline.text-black.border-4.w-auto.bg-white.px-6.py-3.mt-1{href: "images/union_assets/banner-3.png", download: true, type: "image/png"}
       Download
 
 .border-4.p-4.mt-4.bg-gray-200
-  %img{src: "images/union_assets/story-1920x1080.png"}
+  %img{src: "/images/union_assets/story-1920x1080.png"}
   .mt-6.mb-1.flex
     %a.no-underline.text-black.border-4.w-auto.bg-white.px-6.py-3.mt-1{href: "images/union_assets/story-1920x1080.png", download: true, type: "image/png"}
       Download (1920x1080)


### PR DESCRIPTION
without this change it works fine on local dev, but the images aren't showing on [kickstarterunited.org](kickstarterunited.org).  weird!  hopefully this fixes it.

here's what we're seeing now on [kickstarterunited.org](kickstarterunited.org):

<img width="1105" height="614" alt="Screenshot 2025-10-04 at 9 51 17 PM" src="https://github.com/user-attachments/assets/e2f97c19-08f8-4f50-bf31-63fe61822de7" />

here's where that link leads to:
<img width="862" height="209" alt="Screenshot 2025-10-04 at 9 51 34 PM" src="https://github.com/user-attachments/assets/db75aa3e-316f-4a32-85df-9c34f312c205" />

my hope is that by adding the `/` it stops it from getting prefixed with `union-assets/`
