### PR TITLE
projects our workers love / creators page

### DIFF
--- a/pages/creators/index.haml
+++ b/pages/creators/index.haml
@@ -1,0 +1,35 @@
+!= render 'templates/layout' do
+  %h1 How creators can support Kickstarter United
+  %ul
+    %li
+      Please sign the
+      %a{href: "https://forms.gle/vzao2seP756SLQKF9", target: "_blank"}
+        Creator Petition In Support of Kickstarter United Workers on Strike.
+      This petition is a collective action led by creators - by adding your name to the petition,
+      you can show Kickstarter management that creators stand with us in our fight for a fair contract.
+      After you've signed it, please share it with other creators in your community!
+    %li
+      Mention KSRU in your campaign story, and link to our website
+      %a{href: "/", target: "_blank"} kickstarterunited.com
+      \.
+      Use
+      %a{href: "/union-assets"} our assets
+      in your campaign story and/or thumbnail.
+      If you do, we'll be happy to feature your project
+      %a{href: "/projects-our-workers-love"} here!
+    %li
+      Share our posts on
+      %a{href: "/socials"} social media,
+      and help us spread the word about the strike.
+    %li
+      Add campaign updates to your projects letting backers know about
+      our strike, and link them to
+      %a{href: "/"} kickstarterunited.com
+    %li
+      %a{href: "https://help.kickstarter.com/hc/en-us/requests/new", target: "_blank"}
+        Submit legitimate support tickets to our Community Support team.
+      We want Kickstarter management to feel the absence of our labor - as soon as the strike ends,
+      we'll get back to helping you resolve these tickets.
+    %li
+      If you have a point of contact at Kickstarter, reach out to them to ask them to
+      meet our demands so we can end the strike and get back to helping your projects succeed.

--- a/pages/creators/index.haml
+++ b/pages/creators/index.haml
@@ -31,12 +31,13 @@
     -#     Submit legitimate support tickets to our Community Support team.
     -#   We want Kickstarter management to feel the absence of our labor - as soon as the strike ends,
     -#   we'll get back to helping you resolve these tickets.
-    %li
-      Send an email directly to Kickstarter’s CEO, Everette Taylor, at
-      %a{href: "mailto:e@kickstarter.com"}e@kickstarter.com
-      and the Kickstarter People Team at
-      %a{href: "mailto:PeopleTeam@kickstarter.com"} PeopleTeam@kickstarter.com
-      expressing your support for our strike.
+    -# Not sure about if we can share these email addresses publicly - gonna wait for feedback
+    -# %li
+    -#   Send an email directly to Kickstarter’s CEO, Everette Taylor, at
+    -#   %a{href: "mailto:e@kickstarter.com"}e@kickstarter.com
+    -#   and the Kickstarter People Team at
+    -#   %a{href: "mailto:PeopleTeam@kickstarter.com"} PeopleTeam@kickstarter.com
+    -#   expressing your support for our strike.
     %li
       Speak at our picket line.
       Our picket lines are from 12pm - 4pm ET Monday - Thursday, we are happy to schedule you anytime in that period

--- a/pages/creators/index.haml
+++ b/pages/creators/index.haml
@@ -25,11 +25,20 @@
       Add campaign updates to your projects letting backers know about
       our strike, and link them to
       %a{href: "/"} kickstarterunited.com
+    -# Not sure about this one yet - gonna wait for feedback from more members of the union
+    -# %li
+    -#   %a{href: "https://help.kickstarter.com/hc/en-us/requests/new", target: "_blank"}
+    -#     Submit legitimate support tickets to our Community Support team.
+    -#   We want Kickstarter management to feel the absence of our labor - as soon as the strike ends,
+    -#   we'll get back to helping you resolve these tickets.
     %li
-      %a{href: "https://help.kickstarter.com/hc/en-us/requests/new", target: "_blank"}
-        Submit legitimate support tickets to our Community Support team.
-      We want Kickstarter management to feel the absence of our labor - as soon as the strike ends,
-      we'll get back to helping you resolve these tickets.
+      Send an email directly to Kickstarter’s CEO, Everette Taylor, at
+      %a{href: "mailto:e@kickstarter.com"}e@kickstarter.com
+      and the Kickstarter People Team at
+      %a{href: "mailto:PeopleTeam@kickstarter.com"} PeopleTeam@kickstarter.com
+      expressing your support for our strike.
     %li
-      If you have a point of contact at Kickstarter, reach out to them to ask them to
-      meet our demands so we can end the strike and get back to helping your projects succeed.
+      Speak at our picket line.
+      Our picket lines are from 12pm - 4pm ET Monday - Thursday, we are happy to schedule you anytime in that period
+      unless there’s another speaker scheduled.
+      Even stopping by for a couple of minutes to say you support us would be appreciated.

--- a/pages/index.haml
+++ b/pages/index.haml
@@ -193,32 +193,12 @@
 
       .solidarity__item#solidarity-assets
         %details{name: "solidarity"}
-          %summary [For Creators] Sign a Creator Petition to Support our Strike
+          %summary For Creators
 
           %div
             %p
-              If you're a creator and want to support us, please sign the
-              %a{href: "https://forms.gle/vzao2seP756SLQKF9", target: "_blank"}
-                Creator Petition In Support of Kickstarter United Workers on Strike.
-              This petition is a collective action led by creators - by adding your name to the petition, you can show
-              Kickstarter management that creators stand with us in our fight for a fair contract.
-
-            %p
-              After you've signed it, please share it with other creators in your community!
-
-      .solidarity__item#solidarity-assets
-        %details{name: "solidarity"}
-          %summary [For Creators] Use Union Assets in Your Kickstarter Campaign
-
-          %div
-            %p
-              Given that we're not asking for anyone to boycott Kickstarter,
-              we’ve created a set of digital assets for you to use in Kickstarter campaign materials, or anywhere
-              else you want to show your support.
-              Please use them freely to support our fight for a fair contract.
-
-            %p
-              %a{href: "/union-assets"} Click here to see and download our union assets.
+              %a{href: "/creators"}
+                If you're a creator and want to support us, click here to see some ways you can help!
 
       .solidarity__item#board-letter
         %details{name: "solidarity"}

--- a/pages/projects-our-workers-love/index.haml
+++ b/pages/projects-our-workers-love/index.haml
@@ -15,3 +15,4 @@
     != render 'pages/projects-our-workers-love/project', slug: "restorationgames/return-to-dark-tower-expeditions"
     != render 'pages/projects-our-workers-love/project', slug: "shiftrpg/shift-rpg"
     != render 'pages/projects-our-workers-love/project', slug: "apexpublications/apex-magazine-2026"
+    != render 'pages/projects-our-workers-love/project', slug: "theninagalaxy/to-love-like-venus"

--- a/pages/projects-our-workers-love/index.haml
+++ b/pages/projects-our-workers-love/index.haml
@@ -1,0 +1,17 @@
+!= render 'templates/layout' do
+  %h1 Projects our Workers Love
+  %p
+    Here we'll be featuring live projects that have expressed support for Kickstarter United.
+  %p
+    If you're a creator,
+    %a{href: "/creators"} here are some ways you can support us.
+    If you have a live project who would like to be featured here, please fill out
+    %a{href: "https://docs.google.com/forms/d/e/1FAIpQLSd3JgEtyy72nD6zAwdZsIMeJ5PMg3pIOtkwR7l1uooCJI9bTA/viewform", target: "_blank"} this form
+    to let us know!
+
+  %ul.mt-6.flex.list-none.p-0.flex-wrap
+    != render 'pages/projects-our-workers-love/project', slug: "ironspike/rigsby-wi-volume-2-burn-it-down-by-se-case"
+    != render 'pages/projects-our-workers-love/project', slug: "ww3/poisongirls"
+    != render 'pages/projects-our-workers-love/project', slug: "restorationgames/return-to-dark-tower-expeditions"
+    != render 'pages/projects-our-workers-love/project', slug: "shiftrpg/shift-rpg"
+    != render 'pages/projects-our-workers-love/project', slug: "apexpublications/apex-magazine-2026"

--- a/pages/projects-our-workers-love/project.haml
+++ b/pages/projects-our-workers-love/project.haml
@@ -1,0 +1,4 @@
+-# locals: slug
+
+%li.m-2
+  %iframe{src: "https://www.kickstarter.com/projects/#{slug}/widget/card.html?v=2", width: "220", height: "420", frameborder: "0", scrolling: "no"}

--- a/templates/resources_links.haml
+++ b/templates/resources_links.haml
@@ -3,3 +3,5 @@
 %a.menu__item{href: "/press"} Press
 %a.menu__item{href: "/socials"} Socials
 %a.menu__item{href: "/union-assets"} Creator Assets
+%a.menu__item{href: "/projects-our-workers-love"} Projects our Workers Love
+%a.menu__item{href: "/creators"} How Creators Can Help


### PR DESCRIPTION
# What

Adds two new pages: `/creators` and `/projects-our-workers-love`

Definitely going a bit rogue here - please let me know if there's anything you'd prefer for me to change!

# See

### Projects our Workers Love page:

<img width="1728" height="1039" alt="Screenshot 2025-10-07 at 10 50 14 AM" src="https://github.com/user-attachments/assets/491f4b54-3c51-4be5-a602-afbf6295c688" />

### Creators page:

<img width="1105" height="704" alt="Screenshot 2025-10-07 at 1 48 14 PM" src="https://github.com/user-attachments/assets/962408c6-ed22-46e1-8939-17c981f48848" />

### Changes to the main page:

<img width="825" height="518" alt="Screenshot 2025-10-06 at 4 32 17 PM" src="https://github.com/user-attachments/assets/9686b6c8-3228-4b88-a2de-ccace13419ec" />

### menu updates:

<img width="405" height="387" alt="Screenshot 2025-10-07 at 10 50 50 AM" src="https://github.com/user-attachments/assets/c438e6b3-9a77-4849-8ec5-a0496fc212a2" />