### PR TITLE
improve mobile experience on PoWL page

### DIFF
--- a/pages/projects-our-workers-love/index.haml
+++ b/pages/projects-our-workers-love/index.haml
@@ -9,7 +9,7 @@
     %a{href: "https://docs.google.com/forms/d/e/1FAIpQLSd3JgEtyy72nD6zAwdZsIMeJ5PMg3pIOtkwR7l1uooCJI9bTA/viewform", target: "_blank"} this form
     to let us know!
 
-  %ul.mt-6.flex.list-none.p-0.flex-wrap
+  %ul.mt-4.flex.list-none.p-0.flex-wrap.justify-evenly
     != render 'pages/projects-our-workers-love/project', slug: "ironspike/rigsby-wi-volume-2-burn-it-down-by-se-case"
     != render 'pages/projects-our-workers-love/project', slug: "ww3/poisongirls"
     != render 'pages/projects-our-workers-love/project', slug: "restorationgames/return-to-dark-tower-expeditions"

--- a/pages/projects-our-workers-love/project.haml
+++ b/pages/projects-our-workers-love/project.haml
@@ -1,4 +1,4 @@
 -# locals: slug
 
-%li.m-2
-  %iframe{src: "https://www.kickstarter.com/projects/#{slug}/widget/card.html?v=2", width: "220", height: "420", frameborder: "0", scrolling: "no"}
+%li.m-1
+  %iframe{src: "https://www.kickstarter.com/projects/#{slug}/widget/card.html?v=2", width: "170", height: "360", frameborder: "0", scrolling: "no"}


### PR DESCRIPTION
# See

Make the PoWL page a little tighter.  On desktop display 4 projects per row, and 2 per row on mobile.

## Before:

### Desktop:

<img width="1725" height="992" alt="Screenshot 2025-10-08 at 1 09 33 PM" src="https://github.com/user-attachments/assets/d060aa70-3bd6-4d99-8b04-1e3745d6e52d" />

### iPhone 14 Pro Max:

<img width="1149" height="986" alt="Screenshot 2025-10-08 at 1 09 54 PM" src="https://github.com/user-attachments/assets/1d38799e-cbb8-4f9c-814d-96e1e1b6c753" />

## After

### Desktop:

<img width="1723" height="992" alt="Screenshot 2025-10-08 at 1 11 06 PM" src="https://github.com/user-attachments/assets/5ce38998-1c84-49da-9ee6-ae7459a57ea8" />

### iPhone 14 Pro Max:

<img width="1151" height="988" alt="Screenshot 2025-10-08 at 1 11 25 PM" src="https://github.com/user-attachments/assets/4082eb5a-cdec-41ff-9c0b-8feaa35f7d8c" />
