### PR TITLE
Add UrgentBanner component with rally banner

### DIFF
--- a/src/components/UrgentBanner/UrgentBanner.astro
+++ b/src/components/UrgentBanner/UrgentBanner.astro
@@ -1,0 +1,32 @@
+---
+import type { HTMLAttributes } from "astro/types";
+
+import "./UrgentBanner.css";
+
+/**
+ * Full-width dark teal banner with animated gradient background, gold accents,
+ * and a bouncy scale-in entrance animation. Breaks out of the content column
+ * to span the full viewport width.
+ *
+ * Does NOT handle outer margins; the instance is responsible for positioning
+ * (e.g. `class="mt-[calc(-2rem+2px)]"`).
+ *
+ * CSS classes available for slot content:
+ * - `.urgent-banner__when`    - callout box with gold left border
+ * - `.urgent-banner__cta`     - oversized pulsing CTA button
+ * - `.urgent-banner__actions` - flex row for secondary action buttons
+ */
+interface Props extends HTMLAttributes<"div"> {
+  /** Text for the gold pill badge (e.g. "TOMORROW") */
+  badge?: string;
+}
+
+const { badge, class: cls, ...props } = Astro.props;
+---
+
+<div {...props} class:list={["urgent-banner surface", cls]}>
+  <div class="urgent-banner__inner">
+    {badge && <p class="urgent-banner__badge">{badge}</p>}
+    <slot />
+  </div>
+</div>

--- a/src/components/UrgentBanner/UrgentBanner.css
+++ b/src/components/UrgentBanner/UrgentBanner.css
@@ -1,0 +1,166 @@
+@reference "../../styles/global.css";
+
+.urgent-banner {
+  --_gold: var(--ksru-color-accent-rich);
+  --_teal: var(--ksru-color-accent);
+  --_green: var(--ksru-color-accent-light);
+
+  /*
+   * Three-layer gradient stack:
+   * 1. Green glow (top-left, drifts via @property animation)
+   * 2. Gold glow  (bottom-right, drifts opposite)
+   * 3. Dark teal base
+   */
+  background:
+    radial-gradient(ellipse at var(--_glow1-x, 20%) var(--_glow1-y, 0%), color-mix(in oklch, var(--_green), transparent 70%) 0%, transparent 60%),
+    radial-gradient(ellipse at var(--_glow2-x, 80%) var(--_glow2-y, 100%), color-mix(in oklch, var(--_gold), transparent 80%) 0%, transparent 50%),
+    radial-gradient(ellipse at 50% 50%, color-mix(in oklch, var(--_teal), black 10%) 0%, var(--_teal) 100%);
+  /* urgent-banner-glow: drifts the gradient glow positions via @property custom properties */
+  /* surface-border-rotate: rotates the animated conic-gradient border (defined in global CSS) */
+  animation: urgent-banner-glow 12s ease-in-out infinite alternate, surface-border-rotate 6s linear infinite;
+  color: #fff;
+  border: 3px solid var(--_gold);
+  border-top: none;
+  box-shadow: 0 0 24px color-mix(in oklch, var(--_gold), transparent 60%);
+  text-align: center;
+
+  /* Full-viewport breakout */
+  margin-inline: calc(50% - 50vw);
+  padding-inline: calc(50vw - 50%);
+  border-radius: 0;
+  border-inline: none;
+
+  /* Animated border via existing keyframes */
+  --surface-border-color: var(--_gold);
+}
+
+/* Bouncy scale-in entrance via @starting-style.
+ * linear() defines a spring-like curve: overshoots to 122%, settles with a small bounce.
+ * Opacity fades in faster (0.3s) so content is visible before the bounce finishes. */
+.urgent-banner__inner {
+  transition: opacity 0.3s ease-out, scale 0.5s linear(0, 0.28, 0.74, 1.04, 1.22, 1.1, 0.97, 1.04, 1);
+  opacity: 1;
+  scale: 1;
+
+  @starting-style {
+    opacity: 0;
+    scale: 0.5;
+  }
+}
+
+/* Feed gold/green into the .surface animated conic-gradient border */
+.urgent-banner::before {
+  --_clr-1: var(--_gold);
+  --_clr-2: var(--_green);
+  border-radius: 0;
+}
+
+.urgent-banner h1 {
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+  line-height: 1.2;
+  margin-block: 0.25rem 0.75rem;
+}
+
+.urgent-banner h1 .highlight {
+  color: var(--_teal);
+}
+
+.urgent-banner strong {
+  color: var(--_gold);
+}
+
+.urgent-banner__badge {
+  display: inline-block;
+  background: var(--_gold);
+  color: var(--_teal);
+  font-weight: 800;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  padding: 0.25em 1em;
+  border-radius: 999px;
+  margin-bottom: 0.5rem;
+}
+
+.urgent-banner__when {
+  background: color-mix(in oklch, var(--_teal), black 20%);
+  border-left: 4px solid var(--_gold);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin-block: 1.25rem;
+  text-align: left;
+  max-width: 28rem;
+  margin-inline: auto;
+}
+
+.urgent-banner__when dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25rem 1rem;
+  align-items: baseline;
+}
+
+.urgent-banner__when dt {
+  color: var(--_gold);
+  font-weight: 700;
+  text-align: right;
+}
+
+.urgent-banner__when dd {
+  margin: 0;
+  font-weight: 600;
+  text-align: left;
+}
+
+.urgent-banner__cta {
+  font-size: 1.2rem;
+  padding: 14px 32px;
+  animation: urgent-banner-pulse 2s ease-in-out infinite;
+}
+
+.urgent-banner__cta:hover,
+.urgent-banner__cta:focus-visible {
+  animation: none;
+}
+
+.urgent-banner__actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.urgent-banner__actions .btn {
+  margin-top: 0;
+}
+
+/* @property registrations allow the gradient glow positions to be animated.
+ * Without these, the browser can't interpolate custom properties in gradients. */
+@property --_glow1-x { syntax: "<percentage>"; initial-value: 20%; inherits: false; }
+@property --_glow1-y { syntax: "<percentage>"; initial-value: 0%; inherits: false; }
+@property --_glow2-x { syntax: "<percentage>"; initial-value: 80%; inherits: false; }
+@property --_glow2-y { syntax: "<percentage>"; initial-value: 100%; inherits: false; }
+
+@keyframes urgent-banner-glow {
+  0% { --_glow1-x: 20%; --_glow1-y: 0%; --_glow2-x: 80%; --_glow2-y: 100%; }
+  50% { --_glow1-x: 70%; --_glow1-y: 30%; --_glow2-x: 30%; --_glow2-y: 70%; }
+  100% { --_glow1-x: 40%; --_glow1-y: 10%; --_glow2-x: 60%; --_glow2-y: 90%; }
+}
+
+@keyframes urgent-banner-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.04); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .urgent-banner {
+    animation: none !important;
+  }
+  .urgent-banner__inner {
+    transition: none;
+  }
+  .urgent-banner__cta {
+    animation: none;
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,10 +5,56 @@ import Logo from "../images/logo.svg";
 import HideFireworkButton from "../components/Firework/HideFireworkButton.astro";
 import Carousel from "../components/Carousel/Carousel.astro";
 import CarouselItem from "../components/Carousel/CarouselItem.astro";
+import UrgentBanner from "../components/UrgentBanner/UrgentBanner.astro";
+
+// Rally auto-hides after 1pm ET on Feb 27, 2026
+const RALLY_CUTOFF = "2026-02-27T18:00:00Z"; // 1pm EST = 6pm UTC
+const showRally = Date.now() < new Date(RALLY_CUTOFF).getTime();
 ---
 
 <BaseLayout title="Home">
-  <Logo class="mx-auto" width={256} height={256} />
+  {showRally && (
+    <UrgentBanner badge="TOMORROW" id="rally" data-cutoff={RALLY_CUTOFF} class="mt-[calc(-2rem+2px)]">
+      <h1><span class="highlight">Rally to End Retaliation</span></h1>
+      <p>
+        On February 11, Kickstarter management terminated bargaining unit members
+        and forced others out, <strong>targeting strike leaders and union
+        activists</strong>, just 3 months after workers ratified a <a href="/contracts/2025">historic contract</a>
+        following a 42-day strike!
+      </p>
+      <p>
+        Join us at a <strong>virtual rally</strong> to demand reinstatement and an
+        end to retaliation.
+      </p>
+      <div class="urgent-banner__when">
+        <dl>
+          <dt>When</dt>
+          <dd>Thursday, February 27 at noon ET / 9am Pacific</dd>
+          <dt>Where</dt>
+          <dd>Virtual (Zoom)</dd>
+        </dl>
+      </div>
+      <p class="mt-4">
+        <a href="/rally" class="btn btn-success urgent-banner__cta">Register for the Rally</a>
+      </p>
+      <div class="urgent-banner__actions">
+        <a href="/petition" class="btn btn-info">Sign the Petition</a>
+        <a href="mailto:e@kickstarter.com" class="btn btn-info">Email the CEO</a>
+      </div>
+    </UrgentBanner>
+  )}
+
+  <script>
+    const rally = document.getElementById("rally");
+    if (rally) {
+      const cutoff = new Date(rally.dataset.cutoff!).getTime();
+      const ms = cutoff - Date.now();
+      if (ms <= 0) rally.remove();
+      else setTimeout(() => rally.remove(), ms);
+    }
+  </script>
+
+  <Logo class="mx-auto mt-24" width={256} height={256} />
 
   <hr />
 


### PR DESCRIPTION
## Summary
- Extract the urgent rally section from `index.astro` into a reusable `UrgentBanner` component
- Animated gradient background, gold accents, bouncy `@starting-style` scale-in entrance using `linear()` easing
- Component does not handle outer margins (instance responsibility)
- All animations respect `prefers-reduced-motion`

<img width="1106" height="637" alt="image" src="https://github.com/user-attachments/assets/787a0d6b-503b-4397-8979-8f29b8c36ed3" />


## Test plan
- [x] `bun astro check` passes with no errors
- [x] `bun run build` succeeds
- [x] Banner visually matches previous inline version
- [x] Entrance animation plays on page load (scale + opacity bounce-in)
- [x] `prefers-reduced-motion` disables all animations