### PR TITLE
Fix day of week on rally banner

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -38,7 +38,7 @@ function getBadge(now: number) {
       <div class="urgent-banner__when">
         <dl>
           <dt>When</dt>
-          <dd>Thursday, February 27 at noon ET / 9am Pacific</dd>
+          <dd>Friday, February 27 at noon ET / 9am Pacific</dd>
           <dt>Where</dt>
           <dd>Virtual (Zoom)</dd>
         </dl>


### PR DESCRIPTION
## Summary
- Feb 27, 2026 is a Friday, not a Thursday. Fixes the day of week shown in the rally banner.

## Test plan
- [ ] Verify banner displays "Friday, February 27 at noon ET / 9am Pacific"