### PR TITLE
Add light/dark theme support

### DIFF
--- a/src/components/AssetBox.astro
+++ b/src/components/AssetBox.astro
@@ -12,11 +12,11 @@ interface Props {
 const { image, button_text, alt_button, alt } = Astro.props;
 ---
 
-<div class="border-4 p-md mt-md bg-gray-200">
+<div class="border-4 p-md mt-md bg-surface-secondary">
   <Image class="mx-auto" src={image} alt={alt || button_text} loading="lazy" />
   <div class="mt-lg mb-1 flex">
     <a
-      class="no-underline text-black border-4 w-auto bg-white px-lg py-3"
+      class="no-underline text-text border-4 w-auto bg-surface px-lg py-3"
       href={image.src}
       download
       type="image/png"
@@ -26,7 +26,7 @@ const { image, button_text, alt_button, alt } = Astro.props;
     {
       alt_button && (
         <a
-          class="no-underline text-black border-4 w-auto bg-white px-lg py-3 ml-md"
+          class="no-underline text-text border-4 w-auto bg-surface px-lg py-3 ml-md"
           href={alt_button.image.src}
           download
           type="image/png"

--- a/src/components/DaysOnStrike/days-on-strike.css
+++ b/src/components/DaysOnStrike/days-on-strike.css
@@ -12,12 +12,12 @@
   }
 
   .days-on-strike__bill {
-    @apply flex-2 shrink-0 basis-auto grid place-items-center border border-green-900/10 p-6 rounded-2xl bg-green-50 text-green-950 inset-shadow-xs inset-shadow-gray-300;
+    @apply flex-2 shrink-0 basis-auto grid place-items-center border border-emerald-900/10 p-6 rounded-2xl bg-emerald-50 text-emerald-950 inset-shadow-xs inset-shadow-neutral-300;
   }
 
   .days-on-strike .day-count {
     color: var(--ksru-color-accent-light);
 
-    @apply mt-0 h-28 w-28 text-5xl shadow-sm shadow-gray-200 border border-gray-300 rounded m-auto px-6 text-center bg-white aspect-square content-center;
+    @apply mt-0 h-28 w-28 text-5xl shadow-sm shadow-neutral-200 border border-neutral-300 rounded m-auto px-6 text-center bg-surface aspect-square content-center;
   }
 }

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -4,7 +4,7 @@ export default function LoadingSpinner() {
       <div role="status">
         <svg
           aria-hidden="true"
-          class="inline w-10 h-10 text-gray-200 animate-spin dark:text-gray-600 fill-green-500"
+          class="inline w-10 h-10 text-border animate-spin fill-emerald-500"
           viewBox="0 0 100 101"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Nav/Nav.astro
+++ b/src/components/Nav/Nav.astro
@@ -6,6 +6,7 @@ import Button from "../../ui/Button/Button.astro";
 import MenuIcon from "../../images/icons/MenuIcon.svg";
 import DrawerMenu from "../../ui/Menu/DrawerMenu.astro";
 import Menu from "../../ui/Menu/Menu.astro";
+import ThemeToggle from "../ThemeToggle.tsx";
 ---
 
 {
@@ -14,6 +15,8 @@ import Menu from "../../ui/Menu/Menu.astro";
 }
 <nav class="page__nav">
   <a class="btn link sr-only" href="#content">Skip to main content</a>
+
+  <ThemeToggle client:load />
 
   {/* Render the mobile menu. */}
   <Button

--- a/src/components/Nav/nav.css
+++ b/src/components/Nav/nav.css
@@ -12,7 +12,7 @@
   }
 
   .page__nav :is(button, .btn):not([popover] *):hover {
-    background-color: color-mix(in srgb, white, transparent 90%);
+    background-color: var(--ksru-color-surface-hover);
   }
 
   .nav__list > * {

--- a/src/components/PressLink.astro
+++ b/src/components/PressLink.astro
@@ -64,7 +64,7 @@ const isExternal = href.startsWith("http");
     font-size: 0.8125rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: light-dark(var(--ksru-cyan-700), var(--ksru-cyan-300));
+    color: var(--ksru-color-accent);
   }
 
   .press-link__title {

--- a/src/components/ThemeToggle.css
+++ b/src/components/ThemeToggle.css
@@ -1,0 +1,4 @@
+.theme-toggle__icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}

--- a/src/components/ThemeToggle.css
+++ b/src/components/ThemeToggle.css
@@ -2,3 +2,46 @@
   width: 1.25rem;
   height: 1.25rem;
 }
+
+/* Star-shaped theme transition - scoped to .theme-star so MPA transitions are unaffected */
+html.theme-star::view-transition-old(root),
+html.theme-star::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+html.theme-star::view-transition-new(root) {
+  clip-path: var(--_star-0);
+  animation: theme-star-expand 1.05s linear forwards;
+  filter: drop-shadow(0 0 24px oklch(0.75 0.15 87))
+    drop-shadow(0 0 60px oklch(0.65 0.1 87 / 0.5));
+}
+
+html.theme-star::view-transition-old(root) {
+  z-index: -1;
+}
+
+/* 12 steps with rotation baked into polygon vertices, radius pre-eased in JS */
+@keyframes theme-star-expand {
+  0% { clip-path: var(--_star-0); }
+  8.33% { clip-path: var(--_star-1); }
+  16.67% { clip-path: var(--_star-2); }
+  25% { clip-path: var(--_star-3); }
+  33.33% { clip-path: var(--_star-4); }
+  41.67% { clip-path: var(--_star-5); }
+  50% { clip-path: var(--_star-6); }
+  58.33% { clip-path: var(--_star-7); }
+  66.67% { clip-path: var(--_star-8); }
+  75% { clip-path: var(--_star-9); }
+  83.33% { clip-path: var(--_star-10); }
+  91.67% { clip-path: var(--_star-11); }
+  100% { clip-path: var(--_star-12); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.theme-star::view-transition-new(root) {
+    animation: none;
+    clip-path: none;
+    filter: none;
+  }
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from "preact/hooks";
+import "./ThemeToggle.css";
+
+type Theme = "system" | "light" | "dark";
+const STORAGE_KEY = "ksru-theme";
+const CYCLE: Theme[] = ["system", "light", "dark"];
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>("system");
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (saved && CYCLE.includes(saved)) {
+      setTheme(saved);
+    }
+  }, []);
+
+  function cycle() {
+    const next = CYCLE[(CYCLE.indexOf(theme) + 1) % CYCLE.length] ?? "system";
+    setTheme(next);
+    document.documentElement.setAttribute("data-theme", next);
+    if (next === "system") {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, next);
+    }
+  }
+
+  const label =
+    theme === "system" ? "System theme" :
+    theme === "light" ? "Light theme" : "Dark theme";
+
+  return (
+    <button
+      type="button"
+      class="btn btn--ghost btn--sm theme-toggle"
+      onClick={cycle}
+      aria-label={label}
+      title={label}
+    >
+      {theme === "system" && (
+        <svg class="theme-toggle__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="2" y="3" width="20" height="14" rx="2" />
+          <path d="M8 21h8m-4-4v4" />
+        </svg>
+      )}
+      {theme === "light" && (
+        <svg class="theme-toggle__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32l1.41 1.41M2 12h2m16 0h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+        </svg>
+      )}
+      {theme === "dark" && (
+        <svg class="theme-toggle__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -3,32 +3,126 @@ import "./ThemeToggle.css";
 
 type Theme = "system" | "light" | "dark";
 const STORAGE_KEY = "ksru-theme";
-const CYCLE: Theme[] = ["system", "light", "dark"];
+const STAR_STEPS = 12;
 
-export default function ThemeToggle() {
-  const [theme, setTheme] = useState<Theme>("system");
+/** Resolve the effective theme from the OS preference. */
+function systemTheme(): "light" | "dark" {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
 
-  useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY) as Theme | null;
-    if (saved && CYCLE.includes(saved)) {
-      setTheme(saved);
-    }
-  }, []);
+/**
+ * Build a rounded star polygon centered at (cx, cy) with optional rotation.
+ * Uses quadratic bezier approximation at each vertex for smooth tips.
+ */
+function starPolygon(
+  cx: number,
+  cy: number,
+  outerR: number,
+  rotation = 0,
+): string {
+  const innerR = outerR * 0.38;
+  const n = 5;
+  const totalVerts = n * 2;
+  const angleStep = Math.PI / n;
+  const start = -Math.PI / 2 + rotation;
+  const arcPts = 3;
+  const rnd = 0.08;
 
-  function cycle() {
-    const next = CYCLE[(CYCLE.indexOf(theme) + 1) % CYCLE.length] ?? "system";
-    setTheme(next);
-    document.documentElement.setAttribute("data-theme", next);
-    if (next === "system") {
-      localStorage.removeItem(STORAGE_KEY);
-    } else {
-      localStorage.setItem(STORAGE_KEY, next);
+  const points: string[] = [];
+
+  for (let i = 0; i < totalVerts; i++) {
+    const angle = start + i * angleStep;
+    const r = i % 2 === 0 ? outerR : innerR;
+
+    const prevAngle = start + ((i - 1 + totalVerts) % totalVerts) * angleStep;
+    const nextAngle = start + ((i + 1) % totalVerts) * angleStep;
+    const prevR = (i - 1 + totalVerts) % 2 === 0 ? outerR : innerR;
+    const nextR = (i + 1) % 2 === 0 ? outerR : innerR;
+
+    const vx = cx + r * Math.cos(angle);
+    const vy = cy + r * Math.sin(angle);
+    const pvx = cx + prevR * Math.cos(prevAngle);
+    const pvy = cy + prevR * Math.sin(prevAngle);
+    const nvx = cx + nextR * Math.cos(nextAngle);
+    const nvy = cy + nextR * Math.sin(nextAngle);
+
+    const sx = vx + (pvx - vx) * rnd;
+    const sy = vy + (pvy - vy) * rnd;
+    const ex = vx + (nvx - vx) * rnd;
+    const ey = vy + (nvy - vy) * rnd;
+
+    for (let j = 0; j <= arcPts; j++) {
+      const t = j / arcPts;
+      const u = 1 - t;
+      const bx = u * u * sx + 2 * u * t * vx + t * t * ex;
+      const by = u * u * sy + 2 * u * t * vy + t * t * ey;
+      points.push(`${bx}px ${by}px`);
     }
   }
 
-  const label =
-    theme === "system" ? "System theme" :
-    theme === "light" ? "Light theme" : "Dark theme";
+  return `polygon(${points.join(", ")})`;
+}
+
+function applyTheme(next: "light" | "dark") {
+  document.documentElement.setAttribute("data-theme", next);
+  localStorage.setItem(STORAGE_KEY, next);
+}
+
+export default function ThemeToggle() {
+  const [mode, setMode] = useState<Theme>("system");
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (saved === "light" || saved === "dark") {
+      setMode(saved);
+    }
+  }, []);
+
+  const effective = mode === "system" ? systemTheme() : mode;
+
+  function cycle(e: MouseEvent) {
+    const next: "light" | "dark" = effective === "dark" ? "light" : "dark";
+
+    if (!("startViewTransition" in document)) {
+      setMode(next);
+      applyTheme(next);
+      return;
+    }
+
+    const cx = e.clientX;
+    const cy = e.clientY;
+    // Use 200vmax equivalent to guarantee full coverage even with rotation
+    const vmax = Math.max(window.innerWidth, window.innerHeight);
+    const maxR = vmax * 2;
+
+    const root = document.documentElement;
+    root.classList.add("theme-star");
+
+    // Generate intermediate steps with progressive rotation (2 full turns)
+    for (let i = 0; i <= STAR_STEPS; i++) {
+      const t = i / STAR_STEPS;
+      const easedR = t * t * maxR; // quadratic ease-in for radius
+      const rotation = t * Math.PI; // half turn (180deg)
+      root.style.setProperty(`--_star-${i}`, starPolygon(cx, cy, easedR, rotation));
+    }
+
+    const transition = (document as any).startViewTransition(() => {
+      setMode(next);
+      applyTheme(next);
+    });
+
+    transition.finished.then(() => {
+      root.classList.remove("theme-star");
+      for (let i = 0; i <= STAR_STEPS; i++) {
+        root.style.removeProperty(`--_star-${i}`);
+      }
+    });
+  }
+
+  const label = effective === "dark" ? "Dark theme" : "Light theme";
 
   return (
     <button
@@ -38,20 +132,30 @@ export default function ThemeToggle() {
       aria-label={label}
       title={label}
     >
-      {theme === "system" && (
-        <svg class="theme-toggle__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="2" y="3" width="20" height="14" rx="2" />
-          <path d="M8 21h8m-4-4v4" />
-        </svg>
-      )}
-      {theme === "light" && (
-        <svg class="theme-toggle__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      {effective === "light" && (
+        <svg
+          class="theme-toggle__icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
           <circle cx="12" cy="12" r="4" />
           <path d="M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32l1.41 1.41M2 12h2m16 0h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
         </svg>
       )}
-      {theme === "dark" && (
-        <svg class="theme-toggle__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      {effective === "dark" && (
+        <svg
+          class="theme-toggle__icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
           <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
         </svg>
       )}

--- a/src/components/UrgentBanner/UrgentBanner.astro
+++ b/src/components/UrgentBanner/UrgentBanner.astro
@@ -24,9 +24,9 @@ interface Props extends HTMLAttributes<"div"> {
 const { badge, class: cls, ...props } = Astro.props;
 ---
 
-<div {...props} class:list={["urgent-banner", cls]} data-theme="inverse">
+<div {...props} class:list={["urgent-banner", cls]} data-theme="dark">
   <div class="urgent-banner__inner">
-    {badge && <p class="urgent-banner__badge">{badge}</p>}
+    {badge && <p class="urgent-banner__badge" data-theme="inverse">{badge}</p>}
     <slot />
   </div>
 </div>

--- a/src/components/UrgentBanner/UrgentBanner.css
+++ b/src/components/UrgentBanner/UrgentBanner.css
@@ -1,44 +1,65 @@
 @reference "../../styles/global.css";
 
 .urgent-banner {
-  --_gold: var(--ksru-color-accent-rich);
-  --_teal: var(--ksru-color-accent);
-  --_green: var(--ksru-color-accent-light);
+  /* Static palette tokens for text/badge/decorative elements */
+  --_gold: var(--ksru-amber-300);
+  --_teal: var(--ksru-cyan-800);
+  --_green: var(--ksru-emerald-600);
+
+  /* Background layer tokens - overridden in dark mode to blend with page */
+  --_bg-base: var(--_teal);
+  --_glow-green-fade: 70%;
+  --_glow-gold-fade: 80%;
 
   /*
    * Three-layer gradient stack:
    * 1. Green glow (top-left, drifts via @property animation)
    * 2. Gold glow  (bottom-right, drifts opposite)
-   * 3. Dark teal base
+   * 3. Base (teal in light, page surface in dark)
    */
   background:
     radial-gradient(
       ellipse at var(--_glow1-x, 20%) var(--_glow1-y, 0%),
-      color-mix(in oklch, var(--_green), transparent 70%) 0%,
+      color-mix(in oklch, var(--_green), transparent var(--_glow-green-fade)) 0%,
       transparent 60%
     ),
     radial-gradient(
       ellipse at var(--_glow2-x, 80%) var(--_glow2-y, 100%),
-      color-mix(in oklch, var(--_gold), transparent 80%) 0%,
+      color-mix(in oklch, var(--_gold), transparent var(--_glow-gold-fade)) 0%,
       transparent 50%
     ),
     radial-gradient(
       ellipse at 50% 50%,
-      color-mix(in oklch, var(--_teal), black 10%) 0%,
-      var(--_teal) 100%
+      color-mix(in oklch, var(--_bg-base), black 10%) 0%,
+      var(--_bg-base) 100%
     );
-  /* urgent-banner-glow: drifts the gradient glow positions via @property custom properties */
-  /* surface-border-rotate: rotates the animated conic-gradient border (defined in global CSS) */
   animation: urgent-banner-glow 12s ease-in-out infinite alternate;
   color: #fff;
   border: 3px solid var(--_gold);
   border-top: none;
-  box-shadow: 0 0 24px color-mix(in oklch, var(--_gold), transparent 60%);
+  box-shadow: none;
   text-align: center;
   padding-block: var(--ksru-space-xl);
 
   border-radius: 0;
   border-inline: none;
+}
+
+/* Dark mode: blend into page surface, glow becomes subtle accent lighting */
+:root[data-theme="dark"] .urgent-banner {
+  --_bg-base: oklch(0.23 0.01 151);
+  --_glow-green-fade: 82%;
+  --_glow-gold-fade: 85%;
+  border-color: color-mix(in oklch, var(--_gold), transparent 80%);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"] .urgent-banner {
+    --_bg-base: oklch(0.23 0.01 151);
+    --_glow-green-fade: 82%;
+    --_glow-gold-fade: 85%;
+    border-color: color-mix(in oklch, var(--_gold), transparent 80%);
+  }
 }
 
 /* Bouncy scale-in entrance via @starting-style.
@@ -64,7 +85,7 @@
 }
 
 .urgent-banner h1 .mark {
-  color: var(--_teal);
+  color: var(--ksru-color-text);
 }
 
 .urgent-banner strong {
@@ -74,7 +95,7 @@
 .urgent-banner__badge {
   display: inline-block;
   background: var(--_gold);
-  color: var(--_teal);
+  color: var(--ksru-color-text);
   font-weight: 800;
   font-size: 0.85rem;
   letter-spacing: 0.1em;
@@ -84,7 +105,7 @@
 }
 
 .urgent-banner__when {
-  background: color-mix(in oklch, var(--_teal), black 20%);
+  background: color-mix(in oklch, var(--_bg-base), black 20%);
   border-left: 4px solid var(--_gold);
   border-radius: 8px;
   padding: var(--ksru-space-md) 1.25rem;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,6 +12,7 @@ const { title } = Astro.props;
 
 <html
   lang="en"
+  data-theme="system"
   data-wf-page="5ce75a59757fff6268d29f8b"
   data-wf-site="5ce75a58757fffbe19d29f88"
 >
@@ -22,6 +23,16 @@ const { title } = Astro.props;
     <meta content="Kickstarter United" property="og:title" />
     <meta content="/images/logo.svg" property="og:image" />
     <meta content="width=device-width, initial-scale=1" name="viewport" />
+
+    {/* Theme: apply saved preference before first paint to prevent FOUC */}
+    <script is:inline>
+      (function() {
+        var t = localStorage.getItem('ksru-theme');
+        if (t === 'light' || t === 'dark') {
+          document.documentElement.setAttribute('data-theme', t);
+        }
+      })();
+    </script>
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link
@@ -59,7 +70,7 @@ const { title } = Astro.props;
       }
     </script>
   </head>
-  <body class="leading-[1.6]" data-theme="light">
+  <body class="leading-[1.6]">
     {/* Global SVG filters (defined once, referenced by CSS) */}
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -85,7 +96,7 @@ const { title } = Astro.props;
       </defs>
     </svg>
     <div class="page page-grid">
-      <header class="page__header col-[bleed]" data-theme="dark">
+      <header class="page__header col-[bleed]">
         <p class="page__logo retro-ribbon retro-ribbon--end">
           <a class="link--standalone" href="/">Kickstarter United</a>
         </p>
@@ -97,7 +108,7 @@ const { title } = Astro.props;
         <slot />
       </main>
 
-      <footer class="page__footer col-[bleed]" data-theme="dark">
+      <footer class="page__footer col-[bleed]">
         <div class="page__footer-social">
           <SocialLinks />
         </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -224,7 +224,7 @@ import Button from "../ui/Button/Button.astro";
   .pullquote {
     font-style: italic;
     line-height: 1.4;
-    border-inline-start: 4px solid var(--ksru-emerald-400);
+    border-inline-start: 4px solid var(--ksru-color-accent-light);
     padding-inline-start: 1.25em;
     padding-block: 0.4em;
     margin-block: var(--ksru-space-sm);
@@ -280,7 +280,7 @@ import Button from "../ui/Button/Button.astro";
     width: 3rem;
     height: 3rem;
     border-radius: 50%;
-    background: var(--ksru-emerald-500);
+    background: var(--ksru-color-accent-light);
     color: white;
     margin-bottom: var(--ksru-space-sm);
   }

--- a/src/pages/contracts/2022.astro
+++ b/src/pages/contracts/2022.astro
@@ -213,7 +213,7 @@ import { Icon } from "astro-icon/components";
 
   .contract-wins__icon {
     flex-shrink: 0;
-    color: var(--ksru-emerald-500);
+    color: var(--ksru-color-accent-light);
     translate: 0 3px;
   }
 
@@ -258,7 +258,7 @@ import { Icon } from "astro-icon/components";
     break-inside: avoid;
     margin: 0 0 var(--ksru-space-lg);
     padding: var(--ksru-space-lg);
-    border-left: 3px solid var(--ksru-emerald-500);
+    border-left: 3px solid var(--ksru-color-accent-light);
     border-radius: var(--ksru-space-sm);
     background: color-mix(in oklch, var(--ksru-color-surface), transparent 50%);
   }

--- a/src/pages/contracts/2025.astro
+++ b/src/pages/contracts/2025.astro
@@ -179,7 +179,7 @@ import { Icon } from "astro-icon/components";
 
   .contract-wins__icon {
     flex-shrink: 0;
-    color: var(--ksru-emerald-500);
+    color: var(--ksru-color-accent-light);
     translate: 0 3px;
   }
 

--- a/src/pages/every-worker-needs-a-union.astro
+++ b/src/pages/every-worker-needs-a-union.astro
@@ -327,7 +327,7 @@ import { Icon } from "astro-icon/components";
       corner-shape: squircle;
       border-radius: 32px;
     }
-    box-shadow: 0 4px 24px oklch(0% 0 0 / 15%);
+    box-shadow: 0 4px 24px var(--ksru-color-shadow);
     scroll-snap-stop: always;
     container-type: scroll-state;
   }

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -87,13 +87,13 @@ import Text from "../ui/typography/Text.astro";
   }
 
   .faq-item__q {
-    color: light-dark(var(--ksru-cyan-700), var(--ksru-cyan-300));
+    color: var(--ksru-color-accent);
     margin-bottom: var(--ksru-space-sm);
   }
 
   .faq-item__a {
     padding-inline-start: var(--ksru-space-lg);
-    border-inline-start: 3px solid var(--ksru-emerald-500);
+    border-inline-start: 3px solid var(--ksru-color-accent-light);
     color: color-mix(in oklch, currentColor, transparent 15%);
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -382,6 +382,16 @@ const hasPetition = "/petition" in redirects;
     flex-shrink: 0;
   }
 
+  :global([data-theme="dark"]) .hero__logo {
+    filter: invert(1);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :global([data-theme="system"]) .hero__logo {
+      filter: invert(1);
+    }
+  }
+
   .hero__headline {
     font-size: clamp(2rem, 6vw, 3.5rem);
     line-height: 1.1;
@@ -612,8 +622,11 @@ const hasPetition = "/petition" in redirects;
     font-weight: 700;
     font-size: 1.25rem;
     color: white;
-    background-color: var(--ksru-color-surface-accent);
-    border-left: 20px solid transparent;
+    background-color: light-dark(
+      var(--ksru-color-surface-accent),
+      var(--ksru-color-surface-secondary)
+    );
+    border-left: 20px solid light-dark(transparent, var(--ksru-color-accent));
     background-clip: border-box;
     border-radius: 0px;
     transition:
@@ -647,7 +660,10 @@ const hasPetition = "/petition" in redirects;
 
   .wins__item[open] summary {
     border-left-color: var(--ksru-color-accent-rich);
-    background-color: color-mix(in oklch, var(--ksru-color-surface-accent), black 15%);
+    background-color: light-dark(
+      color-mix(in oklch, var(--ksru-color-surface-accent), black 15%),
+      var(--ksru-color-surface-secondary)
+    );
     border-radius: var(--wins-radius);
     corner-shape: squircle;
   }
@@ -680,13 +696,19 @@ const hasPetition = "/petition" in redirects;
   }
 
   .wins__item summary:hover {
-    background-color: color-mix(in oklch, var(--ksru-color-surface-accent), white 10%);
+    background-color: light-dark(
+      color-mix(in oklch, var(--ksru-color-surface-accent), white 10%),
+      var(--ksru-color-surface-active)
+    );
   }
 
   /* Separator between items */
   .wins__item + .wins__item summary {
     border-top: 1px solid
-      color-mix(in oklch, var(--ksru-color-surface-accent), white 20%);
+      light-dark(
+        color-mix(in oklch, var(--ksru-color-surface-accent), white 20%),
+        var(--ksru-color-border)
+      );
   }
 
   /* Content panel */
@@ -758,5 +780,26 @@ const hasPetition = "/petition" in redirects;
     .wins__item::details-content {
       transition: none;
     }
+  }
+
+  /* Dark mode: tone down the breaking card */
+  .card-surface.breaking {
+    background-color: light-dark(
+      color-mix(in oklch, var(--ksru-color-accent-light), white 90%),
+      var(--ksru-color-surface-secondary)
+    );
+    color: light-dark(
+      color-mix(in oklch, var(--ksru-color-accent), black 30%),
+      var(--ksru-color-text)
+    );
+    border-color: light-dark(
+      color-mix(in oklch, var(--ksru-color-accent-light), var(--ksru-color-accent) 50%),
+      color-mix(in oklch, var(--ksru-color-accent), transparent 50%)
+    );
+    box-shadow: 0 0 8px
+      light-dark(
+        color-mix(in oklch, var(--ksru-color-accent), transparent 50%),
+        transparent
+      );
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,7 +20,7 @@ const hasPetition = "/petition" in redirects;
   {
     showBanner && (
       <UrgentBanner badge="TAKE ACTION" class="page-grid--subgrid -mt-xl">
-        <h1>
+        <h1 data-theme="inverse">
           <Mark>Stop the Retaliation</Mark>
         </h1>
         <p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -541,7 +541,7 @@ const hasPetition = "/petition" in redirects;
   }
 
   .paths__links a:hover {
-    background: var(--ksru-color-accent);
+    background: var(--ksru-color-surface-accent);
     color: white;
   }
 
@@ -612,7 +612,7 @@ const hasPetition = "/petition" in redirects;
     font-weight: 700;
     font-size: 1.25rem;
     color: white;
-    background-color: var(--ksru-color-accent);
+    background-color: var(--ksru-color-surface-accent);
     border-left: 20px solid transparent;
     background-clip: border-box;
     border-radius: 0px;
@@ -647,7 +647,7 @@ const hasPetition = "/petition" in redirects;
 
   .wins__item[open] summary {
     border-left-color: var(--ksru-color-accent-rich);
-    background-color: color-mix(in oklch, var(--ksru-color-accent), black 15%);
+    background-color: color-mix(in oklch, var(--ksru-color-surface-accent), black 15%);
     border-radius: var(--wins-radius);
     corner-shape: squircle;
   }
@@ -680,19 +680,19 @@ const hasPetition = "/petition" in redirects;
   }
 
   .wins__item summary:hover {
-    background-color: color-mix(in oklch, var(--ksru-color-accent), white 10%);
+    background-color: color-mix(in oklch, var(--ksru-color-surface-accent), white 10%);
   }
 
   /* Separator between items */
   .wins__item + .wins__item summary {
     border-top: 1px solid
-      color-mix(in oklch, var(--ksru-color-accent), white 20%);
+      color-mix(in oklch, var(--ksru-color-surface-accent), white 20%);
   }
 
   /* Content panel */
   .wins__body {
     padding: var(--ksru-space-lg);
-    background-color: white;
+    background-color: var(--ksru-color-surface);
     display: flex;
     flex-wrap: wrap;
     align-items: start;

--- a/src/pages/logos.astro
+++ b/src/pages/logos.astro
@@ -39,7 +39,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       background: white;
       padding: 20px;
       border-radius: 8px;
-      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 2px 10px var(--ksru-color-shadow);
     }
 
     .controls {

--- a/src/pages/may-day-severance-agreement.astro
+++ b/src/pages/may-day-severance-agreement.astro
@@ -166,7 +166,7 @@ import { Icon } from "astro-icon/components";
 
   .mayday-wins__icon {
     flex-shrink: 0;
-    color: var(--ksru-emerald-500);
+    color: var(--ksru-color-accent-light);
     translate: 0 3px;
   }
 </style>

--- a/src/pages/press.astro
+++ b/src/pages/press.astro
@@ -125,9 +125,9 @@ import Text from "../ui/typography/Text.astro";
 
   .press-year__heading {
     padding-bottom: var(--ksru-space-sm);
-    border-bottom: 2px solid var(--ksru-cyan-600);
+    border-bottom: 2px solid var(--ksru-color-accent);
     margin-bottom: var(--ksru-space-md);
-    color: var(--ksru-emerald-500);
+    color: var(--ksru-color-accent-light);
   }
 
   .press-year__links {

--- a/src/pages/socials.astro
+++ b/src/pages/socials.astro
@@ -132,6 +132,16 @@ const socials = [
     margin-inline: auto;
   }
 
+  :global([data-theme="dark"]) .socials-hero__logo {
+    filter: invert(1);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :global([data-theme="system"]) .socials-hero__logo {
+      filter: invert(1);
+    }
+  }
+
   .socials-hero__text {
     display: flex;
     flex-direction: column;

--- a/src/styles/base/legacy.css
+++ b/src/styles/base/legacy.css
@@ -2,7 +2,7 @@
 @layer base {
   body {
     font-family: Montserrat, sans-serif;
-    color: #1a1b1f;
+    color: var(--ksru-color-text);
     font-size: 16px;
     line-height: 28px;
     font-weight: 400;
@@ -64,7 +64,7 @@
     display: block;
     -webkit-transition: opacity 200ms ease;
     transition: opacity 200ms ease;
-    color: #1a1b1f;
+    color: var(--ksru-color-text);
     text-decoration: underline;
   }
 

--- a/src/styles/components/page.css
+++ b/src/styles/components/page.css
@@ -5,7 +5,7 @@
 
 .page__header,
 .page__footer {
-  color: var(--ksru-color-text);
+  color: white;
   --ksru-outline-color: var(--ksru-color-outline-accent);
 }
 
@@ -18,7 +18,10 @@
   padding: 0;
   align-items: stretch;
 
-  background-color: var(--ksru-color-surface-accent);
+  background-color: light-dark(
+    var(--ksru-color-surface-accent),
+    oklch(0.15 0.005 151)
+  );
 }
 
 .page__footer-social {
@@ -54,7 +57,10 @@
   padding: 0;
   align-items: stretch;
 
-  background-color: var(--ksru-color-surface-accent);
+  background-color: light-dark(
+    var(--ksru-color-surface-accent),
+    oklch(0.15 0.005 151)
+  );
 
   position: sticky;
   top: 0;
@@ -68,6 +74,10 @@
     1.5rem
   );
   font-weight: 600;
+}
+
+.page__logo.retro-ribbon {
+  color: light-dark(white, var(--ksru-emerald-400));
 }
 
 .link--standalone {

--- a/src/styles/components/page.css
+++ b/src/styles/components/page.css
@@ -18,7 +18,7 @@
   padding: 0;
   align-items: stretch;
 
-  background-color: var(--ksru-color-accent);
+  background-color: var(--ksru-color-surface-accent);
 }
 
 .page__footer-social {
@@ -54,7 +54,7 @@
   padding: 0;
   align-items: stretch;
 
-  background-color: var(--ksru-color-accent);
+  background-color: var(--ksru-color-surface-accent);
 
   position: sticky;
   top: 0;

--- a/src/styles/components/retro-ribbon.css
+++ b/src/styles/components/retro-ribbon.css
@@ -8,7 +8,7 @@
   text-transform: uppercase;
   letter-spacing: 0.03em;
 
-  background-color: var(--_stop-3);
+  background-color: light-dark(var(--_stop-3), transparent);
   color: white;
 
   --_stop-1: var(--ksru-color-accent-light);
@@ -30,11 +30,11 @@
   }
 
   &::after {
-    background-color: var(--_stop-1);
+    background-color: light-dark(var(--_stop-1), transparent);
   }
 
   &::before {
-    background-color: var(--_stop-2);
+    background-color: light-dark(var(--_stop-2), transparent);
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -26,6 +26,16 @@ ol {
   overflow: hidden;
 }
 
+[data-theme="dark"] .formkit-form {
+  filter: brightness(0.82) saturate(0.6);
+}
+
+@media (prefers-color-scheme: dark) {
+  [data-theme="system"] .formkit-form {
+    filter: brightness(0.82) saturate(0.6);
+  }
+}
+
 @supports (corner-shape: squircle) {
   .formkit-form {
     corner-shape: squircle;

--- a/src/styles/ksru-web.webflow.css
+++ b/src/styles/ksru-web.webflow.css
@@ -17,12 +17,9 @@
 
     --ksru-line-length: 60ch;
 
-    --ksru-color-accent: light-dark(var(--ksru-cyan-800), var(--ksru-cyan-400));
-    --ksru-color-accent-light: light-dark(var(--ksru-emerald-500), var(--ksru-emerald-400));
+    /* Legacy aliases — definitions live in src/ui/tokens/colors.css */
     --ksru-color-bg: var(--ksru-color-surface);
     --ksru-color-bg-loading: light-dark(var(--ksru-neutral-200), var(--ksru-neutral-700));
-    --ksru-color-accent-warm: light-dark(var(--ksru-brown-500), var(--ksru-brown-400));
-    --ksru-color-accent-rich: light-dark(var(--ksru-amber-300), var(--ksru-amber-400));
     --ksru-color-outline: var(--ksru-color-accent);
     --ksru-color-outline-accent: var(--ksru-color-accent-rich);
 

--- a/src/styles/ksru-web.webflow.css
+++ b/src/styles/ksru-web.webflow.css
@@ -17,17 +17,17 @@
 
     --ksru-line-length: 60ch;
 
-    --ksru-color-accent: #034752;
-    --ksru-color-accent-light: #04a862;
-    --ksru-color-bg: #ffffff;
-    --ksru-color-bg-loading: #ddd;
-    --ksru-color-accent-warm: oklch(0.58 0.05 55);
-    --ksru-color-accent-rich: #e0b440;
+    --ksru-color-accent: light-dark(var(--ksru-cyan-800), var(--ksru-cyan-400));
+    --ksru-color-accent-light: light-dark(var(--ksru-emerald-500), var(--ksru-emerald-400));
+    --ksru-color-bg: var(--ksru-color-surface);
+    --ksru-color-bg-loading: light-dark(var(--ksru-neutral-200), var(--ksru-neutral-700));
+    --ksru-color-accent-warm: light-dark(var(--ksru-brown-500), var(--ksru-brown-400));
+    --ksru-color-accent-rich: light-dark(var(--ksru-amber-300), var(--ksru-amber-400));
     --ksru-color-outline: var(--ksru-color-accent);
     --ksru-color-outline-accent: var(--ksru-color-accent-rich);
 
-    --ksru-text-primary: #1a1f1b;
-    --ksru-text-accent: #fff;
+    --ksru-text-primary: var(--ksru-color-text);
+    --ksru-text-accent: white;
 
     font-size: 100%;
   }

--- a/src/ui/Button/button.css
+++ b/src/ui/Button/button.css
@@ -51,7 +51,7 @@
 
   .btn--ghost {
     background: transparent;
-    color: var(--ksru-color-text);
+    color: inherit;
   }
 
   .btn--ghost:hover {

--- a/src/ui/Button/button.css
+++ b/src/ui/Button/button.css
@@ -24,16 +24,16 @@
   /* MARK: Variants */
 
   .btn--primary {
-    background: light-dark(var(--ksru-emerald-500), var(--ksru-emerald-500));
+    background: light-dark(var(--ksru-emerald-500), var(--ksru-emerald-600));
     color: white;
   }
 
   .btn--primary:hover {
-    background: light-dark(var(--ksru-emerald-400), var(--ksru-emerald-400));
+    background: light-dark(var(--ksru-emerald-400), var(--ksru-emerald-500));
   }
 
   .btn--primary:active {
-    background: light-dark(var(--ksru-emerald-600), var(--ksru-emerald-600));
+    background: light-dark(var(--ksru-emerald-600), var(--ksru-emerald-700));
   }
 
   .btn--accent {
@@ -98,16 +98,16 @@
   /* MARK: Legacy aliases (temporary, for unmigrated pages) */
 
   .btn-success {
-    background: light-dark(var(--ksru-emerald-500), var(--ksru-emerald-500));
+    background: light-dark(var(--ksru-emerald-500), var(--ksru-emerald-600));
     color: white;
   }
 
   .btn-success:hover {
-    background: light-dark(var(--ksru-emerald-400), var(--ksru-emerald-400));
+    background: light-dark(var(--ksru-emerald-400), var(--ksru-emerald-500));
   }
 
   .btn-success:active {
-    background: light-dark(var(--ksru-emerald-600), var(--ksru-emerald-600));
+    background: light-dark(var(--ksru-emerald-600), var(--ksru-emerald-700));
   }
 
   .btn-info {

--- a/src/ui/Mark/mark.css
+++ b/src/ui/Mark/mark.css
@@ -40,27 +40,27 @@
     &[data-mark="emerald"] {
       --mark-color: light-dark(
         var(--ksru-emerald-200),
-        var(--ksru-emerald-500)
+        var(--ksru-emerald-700)
       );
     }
 
     &[data-mark="cyan"] {
-      --mark-color: light-dark(var(--ksru-cyan-200), var(--ksru-cyan-500));
+      --mark-color: light-dark(var(--ksru-cyan-200), var(--ksru-cyan-700));
     }
 
     &[data-mark="brown"] {
-      --mark-color: light-dark(var(--ksru-brown-200), var(--ksru-brown-500));
+      --mark-color: light-dark(var(--ksru-brown-200), var(--ksru-brown-600));
     }
 
     &[data-mark="neutral"] {
       --mark-color: light-dark(
         var(--ksru-neutral-200),
-        var(--ksru-neutral-500)
+        var(--ksru-neutral-600)
       );
     }
 
     &[data-mark="red"] {
-      --mark-color: light-dark(var(--ksru-red-200), var(--ksru-red-500));
+      --mark-color: light-dark(var(--ksru-red-200), var(--ksru-red-700));
     }
   }
 }

--- a/src/ui/SocialLinks/social-links.css
+++ b/src/ui/SocialLinks/social-links.css
@@ -5,7 +5,7 @@
   align-items: center;
   justify-content: center;
   gap: var(--ksru-space-sm);
-  color: var(--ksru-color-icon);
+  color: inherit;
 }
 
 .social-link__btn--labeled {

--- a/src/ui/tokens/colors.css
+++ b/src/ui/tokens/colors.css
@@ -36,8 +36,8 @@
   :root {
     --ksru-color-text: light-dark(
       oklch(0.23 0.01 151),
-      oklch(1 0 0)
-    ); /* #1a1f1b / #fff */
+      oklch(0.92 0.005 151)
+    ); /* #1a1f1b / off-white with slight green tint */
     --ksru-color-surface: light-dark(
       oklch(1 0 0),
       oklch(0.23 0.01 151)
@@ -98,16 +98,16 @@
     ); /* branded surface for header/footer/accent sections */
     --ksru-color-accent: light-dark(
       var(--ksru-cyan-800),
-      var(--ksru-cyan-400)
-    ); /* accent text/decorative */
+      oklch(0.65 0.07 212)
+    ); /* accent text/decorative — dark: dimmed cyan, less neon than cyan-400 */
     --ksru-color-accent-light: light-dark(
       var(--ksru-emerald-500),
-      var(--ksru-emerald-400)
-    ); /* green highlights */
+      oklch(0.62 0.11 156)
+    ); /* green highlights — dark: dimmed emerald, less vivid than emerald-400 */
     --ksru-color-accent-rich: light-dark(
       var(--ksru-amber-300),
-      var(--ksru-amber-400)
-    ); /* gold decorative */
+      oklch(0.65 0.11 87)
+    ); /* gold decorative — dark: dimmed amber, less saturated than amber-400 */
     --ksru-color-accent-warm: light-dark(
       var(--ksru-brown-500),
       var(--ksru-brown-400)

--- a/src/ui/tokens/colors.css
+++ b/src/ui/tokens/colors.css
@@ -92,6 +92,10 @@
       oklch(0.23 0.01 151 / 0.1),
       oklch(0 0 0 / 0)
     );
+    --ksru-color-surface-accent: light-dark(
+      var(--ksru-cyan-800),
+      var(--ksru-cyan-700)
+    ); /* branded surface for header/footer/accent sections */
   }
 }
 
@@ -110,4 +114,5 @@
   --color-surface-hover: var(--ksru-color-surface-hover);
   --color-surface-active: var(--ksru-color-surface-active);
   --color-shadow: var(--ksru-color-shadow);
+  --color-surface-accent: var(--ksru-color-surface-accent);
 }

--- a/src/ui/tokens/colors.css
+++ b/src/ui/tokens/colors.css
@@ -94,3 +94,20 @@
     );
   }
 }
+
+/* MARK: Tailwind integration — semantic colors */
+@theme {
+  --color-text: var(--ksru-color-text);
+  --color-surface: var(--ksru-color-surface);
+  --color-text-secondary: var(--ksru-color-text-secondary);
+  --color-surface-secondary: var(--ksru-color-surface-secondary);
+  --color-text-inverse: var(--ksru-color-text-inverse);
+  --color-surface-inverse: var(--ksru-color-surface-inverse);
+  --color-border: var(--ksru-color-border);
+  --color-border-hover: var(--ksru-color-border-hover);
+  --color-border-active: var(--ksru-color-border-active);
+  --color-icon: var(--ksru-color-icon);
+  --color-surface-hover: var(--ksru-color-surface-hover);
+  --color-surface-active: var(--ksru-color-surface-active);
+  --color-shadow: var(--ksru-color-shadow);
+}

--- a/src/ui/tokens/colors.css
+++ b/src/ui/tokens/colors.css
@@ -96,6 +96,22 @@
       var(--ksru-cyan-800),
       var(--ksru-cyan-700)
     ); /* branded surface for header/footer/accent sections */
+    --ksru-color-accent: light-dark(
+      var(--ksru-cyan-800),
+      var(--ksru-cyan-400)
+    ); /* accent text/decorative */
+    --ksru-color-accent-light: light-dark(
+      var(--ksru-emerald-500),
+      var(--ksru-emerald-400)
+    ); /* green highlights */
+    --ksru-color-accent-rich: light-dark(
+      var(--ksru-amber-300),
+      var(--ksru-amber-400)
+    ); /* gold decorative */
+    --ksru-color-accent-warm: light-dark(
+      var(--ksru-brown-500),
+      var(--ksru-brown-400)
+    ); /* warm accent */
   }
 }
 
@@ -115,4 +131,8 @@
   --color-surface-active: var(--ksru-color-surface-active);
   --color-shadow: var(--ksru-color-shadow);
   --color-surface-accent: var(--ksru-color-surface-accent);
+  --color-accent: var(--ksru-color-accent);
+  --color-accent-light: var(--ksru-color-accent-light);
+  --color-accent-rich: var(--ksru-color-accent-rich);
+  --color-accent-warm: var(--ksru-color-accent-warm);
 }

--- a/src/ui/tokens/palettes.css
+++ b/src/ui/tokens/palettes.css
@@ -84,3 +84,78 @@
     --ksru-red-950: oklch(0.19 0.04 25);
   }
 }
+
+/* MARK: Tailwind integration — shade palettes */
+@theme {
+  --color-neutral-50: var(--ksru-neutral-50);
+  --color-neutral-100: var(--ksru-neutral-100);
+  --color-neutral-200: var(--ksru-neutral-200);
+  --color-neutral-300: var(--ksru-neutral-300);
+  --color-neutral-400: var(--ksru-neutral-400);
+  --color-neutral-500: var(--ksru-neutral-500);
+  --color-neutral-600: var(--ksru-neutral-600);
+  --color-neutral-700: var(--ksru-neutral-700);
+  --color-neutral-800: var(--ksru-neutral-800);
+  --color-neutral-900: var(--ksru-neutral-900);
+  --color-neutral-950: var(--ksru-neutral-950);
+
+  --color-emerald-50: var(--ksru-emerald-50);
+  --color-emerald-100: var(--ksru-emerald-100);
+  --color-emerald-200: var(--ksru-emerald-200);
+  --color-emerald-300: var(--ksru-emerald-300);
+  --color-emerald-400: var(--ksru-emerald-400);
+  --color-emerald-500: var(--ksru-emerald-500);
+  --color-emerald-600: var(--ksru-emerald-600);
+  --color-emerald-700: var(--ksru-emerald-700);
+  --color-emerald-800: var(--ksru-emerald-800);
+  --color-emerald-900: var(--ksru-emerald-900);
+  --color-emerald-950: var(--ksru-emerald-950);
+
+  --color-cyan-50: var(--ksru-cyan-50);
+  --color-cyan-100: var(--ksru-cyan-100);
+  --color-cyan-200: var(--ksru-cyan-200);
+  --color-cyan-300: var(--ksru-cyan-300);
+  --color-cyan-400: var(--ksru-cyan-400);
+  --color-cyan-500: var(--ksru-cyan-500);
+  --color-cyan-600: var(--ksru-cyan-600);
+  --color-cyan-700: var(--ksru-cyan-700);
+  --color-cyan-800: var(--ksru-cyan-800);
+  --color-cyan-900: var(--ksru-cyan-900);
+  --color-cyan-950: var(--ksru-cyan-950);
+
+  --color-amber-50: var(--ksru-amber-50);
+  --color-amber-100: var(--ksru-amber-100);
+  --color-amber-200: var(--ksru-amber-200);
+  --color-amber-300: var(--ksru-amber-300);
+  --color-amber-400: var(--ksru-amber-400);
+  --color-amber-500: var(--ksru-amber-500);
+  --color-amber-600: var(--ksru-amber-600);
+  --color-amber-700: var(--ksru-amber-700);
+  --color-amber-800: var(--ksru-amber-800);
+  --color-amber-900: var(--ksru-amber-900);
+  --color-amber-950: var(--ksru-amber-950);
+
+  --color-brown-50: var(--ksru-brown-50);
+  --color-brown-100: var(--ksru-brown-100);
+  --color-brown-200: var(--ksru-brown-200);
+  --color-brown-300: var(--ksru-brown-300);
+  --color-brown-400: var(--ksru-brown-400);
+  --color-brown-500: var(--ksru-brown-500);
+  --color-brown-600: var(--ksru-brown-600);
+  --color-brown-700: var(--ksru-brown-700);
+  --color-brown-800: var(--ksru-brown-800);
+  --color-brown-900: var(--ksru-brown-900);
+  --color-brown-950: var(--ksru-brown-950);
+
+  --color-red-50: var(--ksru-red-50);
+  --color-red-100: var(--ksru-red-100);
+  --color-red-200: var(--ksru-red-200);
+  --color-red-300: var(--ksru-red-300);
+  --color-red-400: var(--ksru-red-400);
+  --color-red-500: var(--ksru-red-500);
+  --color-red-600: var(--ksru-red-600);
+  --color-red-700: var(--ksru-red-700);
+  --color-red-800: var(--ksru-red-800);
+  --color-red-900: var(--ksru-red-900);
+  --color-red-950: var(--ksru-red-950);
+}


### PR DESCRIPTION
## Summary

- Adds full light/dark mode support across the site with a theme toggle in the nav bar
- Introduces design system color tokens (`light-dark()`, semantic accent tokens) so pages adapt automatically
- Star-shaped view transition animation when switching themes (expanding rotating star with amber glow)
- UrgentBanner uses `data-theme` cascade: always dark base, badge/heading flip via `data-theme="inverse"`
- Softens dark mode text to off-white, dims accent colors to reduce neon feel
- Header/footer styled with white text, ghost buttons and social icons inherit parent color
- Migrates 9+ pages from hardcoded palette references to semantic tokens
- FormKit embed dimmed in dark mode via brightness/saturation filter
- Respects `prefers-reduced-motion` for all animations


https://github.com/user-attachments/assets/7b4c3ba5-1630-44e3-928d-cdff44392768



## Test plan

- [ ] Toggle theme via nav button in both light and dark - verify star transition animates from click point
- [ ] Verify header/footer text and social icons are white on teal in both themes
- [ ] Check UrgentBanner looks dark in light mode, blends with surface in dark mode
- [ ] Verify "TAKE ACTION" badge keeps gold background in both themes
- [ ] Check accordion (Prevails section) styling in dark mode
- [ ] Verify logo inverts correctly on homepage and socials page in dark mode
- [ ] Test with system preference set to dark and no explicit theme chosen
- [ ] Confirm `prefers-reduced-motion` disables all animations
- [ ] Check pages with semantic token migration (about, contracts, FAQ, press) in both themes